### PR TITLE
Persist checkout credentials on the tag-mode roles

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -199,9 +199,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # ⚠️ The custodian step below reads issue bodies, which anyone can file. Same reasoning
-          # as the Researcher: `persist-credentials: true` leaves the token in `.git/config` as an
-          # http extraheader, recoverable by anything holding `Read`. Nothing in this job pushes.
+          # ⚠️ The custodian step below reads issue bodies, which anyone can file — keep the
+          # token out of `.git/config`. Safe HERE, uniquely: the route consult runs agent mode,
+          # which configures git auth without ever calling `setupBranch`, so nothing in this job
+          # fetches on checkout's credential. The tag-mode roles must persist theirs (#2).
           persist-credentials: false
       - name: Stash the agent hooks
         run: |
@@ -724,10 +725,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # ⚠️ Same reasoning as the Researcher: `persist-credentials: true` leaves the token in
-          # `.git/config` as an http extraheader, recoverable by anything holding `Read`. This role
-          # never pushes, so there is nothing to lose by dropping it.
-          persist-credentials: false
+          # ⚠️ NO `persist-credentials: false` — it was here, and it broke every private
+          # consumer: this job runs tag mode too, so it fetches before the action configures
+          # git auth. The full finding lives on the Researcher's checkout (#2).
       - name: Stash the agent hooks
         run: |
           if [ ! -d "$RUNNER_TEMP/team-src" ]; then
@@ -880,17 +880,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # ⚠️ THE ONLY CHECKOUT HERE THAT SETS THIS, and it closes a hole the "no shell" rule
-          # does not. `actions/checkout` defaults to `persist-credentials: true`, which leaves the
-          # token in `.git/config` as an `http.<host>.extraheader` — so an agent with nothing but
-          # `Read` can recover a live credential from a FILE, no command execution required, and
-          # then post it anywhere with WebFetch. Removing Bash was necessary and, on its own, not
-          # sufficient (#669).
-          #
-          # Safe to disable here because nothing in this job uses git after checkout: the model
-          # only reads, and the hooks authenticate through `gh` with a token from their own step
-          # env. ⚠️ Do NOT copy this to the authoring jobs — they push, and it would break them.
-          persist-credentials: false
+          # ⚠️ NO `persist-credentials: false` here, though #669 added it to keep the token out
+          # of `.git/config`, where bare `Read` recovers it. Two findings retired it (#2). Its
+          # premise — "nothing in this job uses git after checkout" — was false: tag mode fetches
+          # the source branch BEFORE the action configures its own git auth (`setupBranch`
+          # precedes `configureGitAuth`, src/modes/tag/index.ts), so the fetch has only
+          # checkout's credential, and without one every PRIVATE consumer dies at branch setup —
+          # while a public repo fetches anonymously and never shows it. And the flag never
+          # guarded the model window anyway: `configureGitAuth` re-embeds the job token in the
+          # origin URL in `.git/config` for the whole run, whatever checkout persisted. Measured
+          # on the first private consumer (#2). What holds this role's line is "no shell" (#665)
+          # and the token's own narrow grant — not this flag.
       - id: prompt
         uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -33,6 +33,12 @@ class TeamWorkflow(unittest.TestCase):
         self.assertIn(".claude-team/setup.sh", TEAM)
         self.assertIn(".claude-team/prompts", ACTION)
 
+    def test_only_the_delegate_checkout_drops_credentials(self):
+        lines = TEAM.splitlines()
+        settings = [i for i, l in enumerate(lines) if l.strip() == "persist-credentials: false"]
+        self.assertEqual(len(settings), 1)
+        self.assertLess(settings[0], lines.index("  architect:"))
+
     def test_no_comment_line_inside_if_blocks(self):
         lines = TEAM.split("\n")
         for i, line in enumerate(lines):


### PR DESCRIPTION
## Summary

Closes #2. The first private consumer (brewdocs.beer-kb, run 32205459996) exposed it: **tag mode's `setupBranch` fetches the source branch before `configureGitAuth` runs** (`src/modes/tag/index.ts:67` vs 84–107), so that fetch rides entirely on the credential `actions/checkout` persisted — and the `researcher` and root `claude` checkouts dropped theirs (#669's hardening). Public repos fetch anonymously and hide the defect; private ones die: `fatal: could not read Username for 'https://github.com'`.

The flag also never guarded the window it was written for: `configureGitAuth` → `replaceCheckoutCredentials` re-embeds the job token in the **origin remote URL in `.git/config` for the entire model run** (the default path in `git-config.ts`), whatever checkout persisted. What actually holds the Researcher's line is no-shell (#665) plus the token's narrow grant.

- `researcher` + `claude`: flag dropped (back to the default, matching every author job, whose branch setup works on private repos for exactly this reason); the finding recorded in place.
- `delegate`: keeps the flag — its route consult runs **agent mode**, which configures auth without ever calling `setupBranch` (verified in `src/modes/agent/index.ts`); comment made self-contained.
- New test `test_only_the_delegate_checkout_drops_credentials` pins all three.

## Verification

Full suite: 57 tests OK (includes the new regression test and the no-consumer-names invariant, which caught and corrected an origin-specific reference in the first draft of the comment).

After merge: cut `v1.1` per the release procedure, bump brewdocs.beer-kb's stub pin, retrigger the drill on its #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)