### PR TITLE
Read the handoff from every author step

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -1631,7 +1631,7 @@ jobs:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
           # `remaining` decides whether the task closes — the author's only structured way to say
           # it did not finish. `commitMessage` names the commit the hook makes.
-          HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
+          HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output || steps.tester.outputs.structured_output || steps.writer.outputs.structured_output }}
         run: "$RUNNER_TEMP/agent-bin/work-completion.py"
 
       # ⚠️ THE OTHER EXIT. A failed model step or a conflicted landing pushes the run's changes to
@@ -1723,7 +1723,7 @@ jobs:
           # closing keyword was present, never why it was absent — so an author that deliberately
           # left it off had that decision overwritten, and #617 closed as completed with its
           # wiring never written.
-          HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
+          HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output || steps.tester.outputs.structured_output || steps.writer.outputs.structured_output }}
         run: "$RUNNER_TEMP/agent-bin/finish-pr.py"
       - name: Persist the author's handoff
         if: always()
@@ -1744,7 +1744,7 @@ jobs:
           # whichever author ran — they are alternatives and emit the same schema, so `||`
           # takes the one that produced output. Empty when neither ran or the step failed,
           # which the hook treats as "nothing to post" rather than an error.
-          HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
+          HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output || steps.tester.outputs.structured_output || steps.writer.outputs.structured_output }}
         run: "$RUNNER_TEMP/agent-bin/post-handoff.py"
       - name: Update the story's task order
         if: always()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -33,6 +33,13 @@ class TeamWorkflow(unittest.TestCase):
         self.assertIn(".claude-team/setup.sh", TEAM)
         self.assertIn(".claude-team/prompts", ACTION)
 
+    def test_handoff_reads_every_author_step(self):
+        handoffs = [l for l in TEAM.splitlines() if "HANDOFF:" in l and "steps." in l]
+        self.assertEqual(len(handoffs), 3)
+        for line in handoffs:
+            for step in ("implementor", "designer", "tester", "writer"):
+                self.assertIn(f"steps.{step}.outputs.structured_output", line)
+
     def test_only_the_delegate_checkout_drops_credentials(self):
         lines = TEAM.splitlines()
         settings = [i for i, l in enumerate(lines) if l.strip() == "persist-credentials: false"]


### PR DESCRIPTION
## Summary

Closes #7. All three `HANDOFF:` envs chained only `steps.implementor` and `steps.designer` — the Writer and Tester steps' structured outputs had **no consumer**, so a no-op Writer exit with a correct `remaining: []` handoff stalled its task open and the cascade dark (measured on brewdocs run 32212821349 / issue #1220). The oldest trap in the book, in mirror form: an output produced with no reader — and invisible because both roles normally commit, which closes by the commits path.

One-line fix ×3: chain all four steps' `structured_output`. New test `test_handoff_reads_every_author_step` pins every HANDOFF expression to all four author steps.

## Verification

Suite green (58, including the new pin). After merge, brewdocs (canary, `@mainline`) picks this up immediately — retriggering brewdocs#1220 is the live proof: the Writer's no-op handoff should close the task and cascade to #1221. kb (pinned `v1.1`) inherits at the next tag; its Centennial task closes by commits, so it is unaffected by this bug today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)