### PR TITLE
Give every author step the handoff schema

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -1526,6 +1526,7 @@ jobs:
             --model sonnet
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
             --max-turns 80
+            --json-schema '${{ steps.schema.outputs.body }}'
 
       # ── Writer ──
       # The tech writer. Owns documentation: every CLAUDE.md, the agent instruction files
@@ -1604,6 +1605,7 @@ jobs:
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*)"
             --max-turns 80
+            --json-schema '${{ steps.schema.outputs.body }}'
 
       # ── Once, for the job ──
       # ⚠️ BEFORE finish-pr.py, and the order is load-bearing: the story's PR must not be opened

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -33,6 +33,9 @@ class TeamWorkflow(unittest.TestCase):
         self.assertIn(".claude-team/setup.sh", TEAM)
         self.assertIn(".claude-team/prompts", ACTION)
 
+    def test_every_author_step_carries_the_handoff_schema(self):
+        self.assertEqual(TEAM.count("--json-schema '${{ steps.schema.outputs.body }}'"), 4)
+
     def test_handoff_reads_every_author_step(self):
         handoffs = [l for l in TEAM.splitlines() if "HANDOFF:" in l and "steps." in l]
         self.assertEqual(len(handoffs), 3)


### PR DESCRIPTION
## Summary

Closes #9 — the producer half of #7. The live proof run for #8 (brewdocs 32213699556) still landed an empty `HANDOFF` because `--json-schema` was only ever passed to the implementor and designer model steps: a Tester or Writer **couldn't** return structured output, which is why the Writer reported its no-op in prose, twice. Two lines (tester + writer `claude_args`) and a sibling regression test asserting all four author steps carry the schema.

With both halves in place the chain is: Writer returns the handoff → the fixed env delivers it → `work-completion.py` sees `remaining: []` → closes the task, swaps the label, cascades.

## Verification

Suite green (59). Live proof after merge: retrigger brewdocs#1220 a third time — expect the task to close and the cascade to dispatch #1221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)