### PR TITLE
Name stub runs by trigger provenance, not 'Delegate'

### DIFF
--- a/templates/consumer-stub.yml
+++ b/templates/consumer-stub.yml
@@ -13,7 +13,11 @@ run-name: >-
   || contains(github.event.comment.body || github.event.review.body, '@claude/writer') && 'Writer'
   || contains(github.event.comment.body || github.event.review.body, '@claude/designer') && 'Designer'
   || contains(github.event.comment.body || github.event.review.body, '@claude/security') && 'Security'
-  || 'Delegate' }}
+  || github.event_name == 'issues' && github.event.label.name != '@claude' && format('Label {0}', github.event.label.name)
+  || github.event_name == 'issues' && endsWith(github.actor, '[bot]') && 'Cascade'
+  || github.event_name == 'issues' && 'Run'
+  || contains(github.event.comment.body || github.event.review.body, '@claude') && 'Root'
+  || 'Comment' }}
   · #${{ github.event.issue.number || github.event.pull_request.number }}
   ${{ github.event.issue.title || github.event.pull_request.title }}
 


### PR DESCRIPTION
## Summary

Same change as brewdocs.beer#1230, in the template so new consumers start with it: the `issues`-path catch-all becomes **Cascade** / **Run** / **Label <name>** / **Root** / **Comment** — trigger provenance, which is all a run-name can know (routing happens inside the run). `endsWith(github.actor, '[bot]')` keeps the Cascade arm generic across consumers' App slugs.

## Verification

Suite green (59). Expression parse validated on the brewdocs copy via the scratch-branch phantom-run check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)