### PR TITLE
Let the repairs schema offer `task`, which the hook already accepts

### DIFF
--- a/schemas/repairs.json
+++ b/schemas/repairs.json
@@ -11,7 +11,7 @@
           "kind": {
             "type": "string",
             "enum": ["board-item", "sub-issue-link", "classification-label"],
-            "description": "board-item: put an issue or PR on the project board. sub-issue-link: parent a child to the issue that owns it. classification-label: apply the epic/spike/bug/story label that says what an issue IS - never a routing label, which is the maintainer decision. ⚠️ Three kinds is the whole repertoire, on purpose: anything else, including a missing branch, goes in `unrepairable` where a human acts on it."
+            "description": "board-item: put an issue or PR on the project board. sub-issue-link: parent a child to the issue that owns it. classification-label: apply the epic/spike/bug/story/task label that says what an issue IS - never a routing label, which is the maintainer decision. ⚠️ Three kinds is the whole repertoire, on purpose: anything else, including a missing branch, goes in `unrepairable` where a human acts on it."
           },
           "target": {
             "type": "string",
@@ -23,7 +23,7 @@
           },
           "label": {
             "type": "string",
-            "description": "For classification-label only: one of epic, spike, bug, story. ⚠️ The hook rejects anything else, so a routing label cannot be applied through here even if asked for."
+            "description": "For classification-label only: one of epic, spike, bug, story, task. ⚠️ The hook rejects anything else, so a routing label cannot be applied through here even if asked for."
           },
           "wrong": {
             "type": "string",

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -49,3 +49,15 @@ class Scrub(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class RepairSchemaMatchesTheHook(unittest.TestCase):
+    """The schema is what the model reads; the hook is what enforces. They must agree."""
+
+    def test_every_classification_the_hook_accepts_is_offered_by_the_schema(self):
+        import json, pathlib, re
+        root = pathlib.Path(__file__).resolve().parent.parent
+        hook = (root / "hooks/apply-repairs.py").read_text()
+        allowed = set(re.search(r"CLASSIFICATION = \{([^}]*)\}", hook).group(1).replace('"', "").replace(" ", "").split(","))
+        schema = json.dumps(json.load(open(root / "schemas/repairs.json")))
+        missing = [label for label in allowed if label not in schema]
+        self.assertEqual(missing, [], f"the hook accepts {missing} but the schema never mentions them")


### PR DESCRIPTION
## Summary

Closes #15. The custodian on brewdocs.beer#1269 found task #1275 missing its `task` label, could see the fix, and **declined it**: *"The classification-label repair kind only accepts epic/spike/bug/story — task isn't in that repertoire."*

It was right about the schema and wrong about the system. `hooks/apply-repairs.py:51` is `CLASSIFICATION = {"epic", "spike", "bug", "task", "story"}` — the hook has always accepted `task`. Two schema descriptions said otherwise, and the schema is what the model reads (`--json-schema`), so it self-censored a repair it was fully able to make. The cost isn't a wrong repair; it's a capability quietly lost, with the gap written into `unrepairable` for a human to clear by hand.

New test derives the hook's set with a regex and asserts the schema mentions every member, so the two can't drift apart again. ⚠️ Verified against the stale schema, where it fails with *"the hook accepts ['task'] but the schema never mentions them"* — it isn't a test that passes either way.

## Verification

Full suite **63 OK**. Schema re-parsed as JSON after editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)