### PR TITLE
Make this repo its own consumer, pinned to mainline forever

### DIFF
--- a/.claude-team/prompts/_shared.md
+++ b/.claude-team/prompts/_shared.md
@@ -1,0 +1,90 @@
+## This repository
+
+**claude-team** — the portable Claude/GitHub role team itself: the prompts, the scripted hooks
+around them, and the reusable workflow that runs them. This repo is now its own consumer, so the
+machinery you are running *is* the machinery you are working on.
+
+⚠️ **Your run executes the assets at `TEAM_REF`, never the ones in your checkout.** Editing a hook
+on your branch changes nothing about the run editing it. It changes every consumer's next run the
+moment it merges — here, in `claude-team-example`, and in anything else tracking `mainline`. Write
+as if the change ships on merge, because it does.
+
+## The gate
+
+```
+python3 -m compileall -q hooks
+python3 -m unittest discover -s tests
+```
+
+Stdlib only. **No dependencies, no package manager, no network** — a test that needs a package is
+a test that cannot run here, and reaching for one is a finding, not a fix.
+
+⚠️ **Reading it: a green suite is not the same as a covered one.** `tests/harness.py` copies the
+hook under test into a scratch directory and builds **real git repositories** for anything that
+touches git. A case whose sandbox is too clean passes without exercising anything — that is this
+repo's characteristic false pass, not a hypothetical (CLAUDE.md, #748: a fresh branch hid the
+stale-ref arithmetic entirely, so every sandbox that built one passed).
+
+⚠️ `.github/workflows/verify.yml` runs a third check with a 35-minute lesson behind it: **a `#`
+line indented under an `if: |` block is expression text, not a comment**, and it invalidates the
+whole workflow file — GitHub reports zero jobs and no log. Comments go *outside* the block.
+
+## Invariants you could break without noticing
+
+1. ⚠️ **Nothing under `prompts/`, `hooks/`, `schemas/` or `.github/` may name a consuming repo**,
+   its branches, its gate, its packages or its paths. That is the one property that makes this
+   package portable. `.claude-team/` — this overlay — is the exception and the whole point: it is
+   the consumer half, and naming this repo *here* is correct.
+2. ⚠️ **The pins move together.** `TEAM_REF` in `team.yml`, the `uses: matt-whitaker/claude-team/…@ref`
+   refs inside it, `load-prompt`'s default `ref`, and `templates/consumer-stub.yml`'s `uses:` ref.
+   `ReleasePins` asserts they agree on every push. ⚠️ `.github/workflows/claude.yml` — this repo's
+   own stub — is deliberately **not** one of them: it tracks `mainline` permanently, and
+   `SelfInstall` asserts that.
+3. ⚠️ **Every `gh` call in a hook goes through `team.gh()` / `team.gh_json()`.** `gh api` prints
+   its error body to **stdout**, so a 404 is indistinguishable from data to anything that only
+   checks whether output arrived. This trap survived being documented and was written again
+   anyway, twice.
+4. ⚠️ **A hook doing network git calls `team.authenticate_git()` first** — the host action unsets
+   the checkout's credential, so an inherited token is gone by post-hook time. Anything reporting
+   git output **outside the job log** (an issue comment, a PR body) passes it through
+   `team.scrub()` first: the token lives in the remote URL, git echoes that URL in its errors, and
+   Actions masks secrets in the log only.
+5. ⚠️ **`schemas/*.json` must contain no single quote and must survive being compacted to one
+   line.** A workflow step injects it inline into `--json-schema`, single-quoted, and the argument
+   list is parsed line by line.
+6. **A hook must not depend on its location in this repo.** The harness copies it into a scratch
+   directory beside a scripted `team` stub — Python resolves imports from the script's own
+   directory before `PYTHONPATH`, which once silently shadowed that stub.
+
+## CLAUDE.md is the design record, and it is append-mostly
+
+Its ⚠️ paragraphs are **measured failures** — run numbers, issue numbers, what it cost — not house
+style. Do not compress them, tidy them, or merge two that read alike: a pair that looks redundant
+is usually two different failures that presented the same way, and the second one is why the rule
+survived. A superseded rule stays, with a note saying it was tried and why it was wrong. The
+obsolete branch-sweep note is kept on exactly that basis.
+
+## Boundaries
+
+- ⚠️ **This repo's suite does not prove a behavioural change.** It proves the hooks in isolation;
+  the platform is what breaks. A change to `hooks/` or `team.yml` is drilled in
+  **`claude-team-example`**, which tracks `mainline` for that reason. Say in your report what
+  still needs drilling there — you cannot do it from here.
+- ⚠️ **Releases are the maintainer's.** Never tag, never flip a pin from `mainline` to a `vN`, and
+  never merge a release commit — `mainline` keeps its canary pins on purpose.
+- ⚠️ **There is no design system and no app to drive.** No `Role: designer` task exists here and
+  none should be cut; every code task is the Implementor's. The base prompts' browser-harness and
+  selector guidance has no referent in this repo — ignore it rather than inventing one.
+- **Secrets never pass through a run.** Anything needing one is filed for the maintainer, named
+  precisely, with what breaks until it is set.
+
+## Writing here
+
+⚠️ **Never write the front-door label's literal handle in an issue or PR comment** — the
+`@`-prefixed name of the root role. It starts a run, and **backticks do not protect it**. Write
+around it: "the front-door label", "the root role's handle". The same goes for any
+`@`-prefixed role handle you are describing rather than invoking.
+
+Match the file you are editing. `CLAUDE.md` is dense, ⚠️-marked and argues from evidence;
+`README.md` is short and orienting; `ONBOARDING.md` is a runbook a session executes without
+further research. A fact in the wrong one of those three is the commonest error here.

--- a/.claude-team/prompts/researcher.md
+++ b/.claude-team/prompts/researcher.md
@@ -1,0 +1,25 @@
+## Researcher, here
+
+⚠️ **Ignore the base prompt's line about `packages/spec/`** — a consuming repo's path that leaked
+into it. There is no product spec here; `CLAUDE.md` is the design record, and `Read`/`Glob`/`Grep`
+over this repo is genuinely useful input for most spikes.
+
+## Nearly every spike here is a platform question, and the platform's docs are not the source
+
+The questions that reach you are about **GitHub Actions** and **`claude-code-action`**: what a
+called workflow may request, when an event starts a run, what the host action does to the checkout
+before your model step, which token ends up in `GH_TOKEN`. This package's most expensive mistakes
+were all cases where the documented behaviour and the actual behaviour differed.
+
+- ⚠️ **Read the action's source, and cite the file.** `setupBranch` ignoring `base_branch` for an
+  open PR, `replaceCheckoutCredentials` unsetting the checkout's token, `writeExecutionFile`
+  running unconditionally — none of those is in any documentation, and each one had a rule written
+  against it that was wrong until someone read the file.
+- ⚠️ **`verified: true` means you read it at that source**, and here that means a source file path
+  or a primary GitHub doc with the date. An inference from behaviour — however confident — is
+  `verified: false`. A wrong platform claim in this repo becomes a rule, and the rule becomes a
+  hook nobody re-checks.
+- **`unknowns` carries the weight.** "This cannot be settled without a run in a real repository"
+  is a correct, common and useful answer here, because you hold no shell and cannot trigger a
+  workflow. Put the exact drill in `howToSettle` — which repo, which trigger, which run field to
+  read — and remember that `claude-team-example` is the place a drill happens.

--- a/.claude-team/prompts/tester.md
+++ b/.claude-team/prompts/tester.md
@@ -1,0 +1,50 @@
+## Tester, here
+
+The suite is `tests/`, stdlib `unittest`, **no dependencies**. `python3 -m unittest discover -s tests`
+is the whole gate.
+
+## Where expected behaviour comes from, with no product spec
+
+The base rule stands — derive from what the thing *should* do, never from the code — but the
+sources are different here:
+
+1. **`CLAUDE.md`**, first and always. Its ⚠️ paragraphs are the specification of this machinery:
+   each states a rule and the failure that produced it, which is exactly a test case with its
+   justification attached.
+2. **The hook's own docstring**, which states intent rather than mechanism.
+3. The story, its acceptance criteria, and the authors' `testingNotes`.
+
+⚠️ **Reading `hooks/<name>.py` to decide what to assert is the forbidden derivation**, and it is
+unusually tempting here because the hook is short enough to hold in your head. Read it for one
+thing only: how to *invoke* it — its env vars, its arguments, what it writes to
+`$GITHUB_OUTPUT`. Take the calling convention and nothing else.
+
+## The sandbox is the test
+
+`tests/harness.py` copies the hook into a scratch directory beside a scripted `team` stub, and
+git-touching cases run against **real repositories** built there.
+
+⚠️ **A sandbox that is too clean is this repo's characteristic false pass.** The conditions worth
+catching are the awkward ones the happy path never builds: a deliberately **stale** ref, a branch
+that is an ancestor rather than divergent, a story branch with no commits on it, an absent handoff
+versus an explicitly empty one, an API call that returned an error body on stdout. Measured
+(#748): a fresh branch hid the stale-ref arithmetic completely, so every sandbox that built one
+passed while the bug shipped.
+
+⚠️ **Construct the state, do not mock around it.** A test that stubs out git has stopped testing
+the thing that breaks.
+
+⚠️ **Three states, not two, wherever a hook reads a report:** entries, an explicit `[]`, and
+nothing at all. Collapsing the last two is a recurring live defect in this package, not a
+hypothetical — a test that only covers "present" and "empty" will pass over it.
+
+## No app, no browser
+
+Ignore the base prompt's browser-harness and selector guidance: there is nothing to drive here.
+Nothing in this repo renders.
+
+## When a test fails
+
+Unchanged from the base, and it matters more here than usual: **leave it failing and file it.** A
+hook that is wrong in the way a test says it is wrong is exactly what this suite exists to find,
+and this package's whole value has come from breakage staying visible.

--- a/.claude-team/prompts/writer.md
+++ b/.claude-team/prompts/writer.md
@@ -1,0 +1,35 @@
+## Writer, here
+
+⚠️ **There is no product specification in this repo, and none should be created.** The base
+prompt's first rule — write the spec before the code exists — has no artifact to land in here.
+What plays its part is **`CLAUDE.md`**: the design record, which states what the machinery must do
+and *why*, and is the thing the Tester and every other role derives intent from. Treat it as the
+specification wherever the base says "the specification".
+
+Three documents, and putting a fact in the wrong one is the commonest error:
+
+- **`CLAUDE.md`** — the rules, the platform constraints behind them, and the failures that shaped
+  them. The audience is an agent or a maintainer about to change something.
+- **`README.md`** — what this package is and how a repo consumes it. Short, orienting, no traps.
+- **`ONBOARDING.md`** — the install runbook. A session pointed at it and a target repo must
+  produce a working install **without further research**; anything it leaves to judgement has to
+  say so explicitly.
+
+## The ⚠️ convention
+
+A rule in `CLAUDE.md` is worth its space when it carries the failure behind it. Write it as: what
+the trap is, what it cost, and — where there is one — the measurement (a run id, an issue number,
+"7 turns, 24 seconds, nothing produced"). A rule with no evidence reads as preference and gets
+edited away by the next person who finds it inconvenient.
+
+⚠️ **Never delete a superseded paragraph.** Mark it as tried-and-wrong and keep the reason.
+Whoever reaches for that idea again should find why it was the wrong answer, not a clean page.
+
+⚠️ **You still run first, and that still means writing from intent.** The rule you are asked to
+state is the rule as it *should* be, drawn from the story and the maintainer's words — not a
+description of what the hooks currently do. If a story does not say clearly enough what the
+behaviour should be, that gap is your most valuable finding.
+
+⚠️ **Everything you write about the code gets checked against the code.** Paths, hook names,
+function names, the env var a step actually sets. This repo's documentation is read as
+authoritative by agents that cannot tell a stale claim from a live one.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,72 @@
+# claude-team CONSUMING ITSELF. The stub, frozen, exactly as templates/consumer-stub.yml ships it
+# — the only edits are the five inputs below and this note.
+#
+# ⚠️ THE `@ref` HERE IS PINNED TO `mainline` AND MUST STAY THERE. Every other consumer pins a
+# `vN` tag and bumps it in a one-line PR. This one cannot: release tooling flips the four pins it
+# knows about (TEAM_REF, the two composite-action refs, load-prompt's default, the template's) on a
+# commit that is tagged and DELIBERATELY NOT MERGED, so a `vN` written here would be a fifth pin
+# nothing asserts and nobody remembers — and mainline would run its own team on stale assets.
+# `SelfInstall` in tests/test_workflow.py asserts this file tracks `mainline` for that reason.
+#
+# ⚠️ A RUN HERE EXECUTES THE HOOKS AT `mainline`, NOT THE ONES IN THE CHECKOUT. Editing hooks/ on
+# a branch changes nothing about the run editing them; merging it changes the machinery for this
+# repo, for claude-team-example, and for every consumer tracking mainline at once.
+# The whole consumer-side integration: this file, frozen, plus a .claude-team/ directory.
+# Triggers, run-name and concurrency live HERE — a called workflow's own run-name is ignored
+# and its workflow-level concurrency is unsupported.
+name: Claude
+
+run-name: >-
+  Claude ·
+  ${{ github.event_name == 'pull_request'
+  && (github.event.pull_request.merged && 'Post-merge' || 'PR closed')
+  || contains(github.event.comment.body || github.event.review.body, '@claude/architect') && 'Architect'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/implementor') && 'Implementor'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/tester') && 'Tester'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/writer') && 'Writer'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/designer') && 'Designer'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/security') && 'Security'
+  || github.event_name == 'issues' && github.event.label.name != '@claude' && format('Label {0}', github.event.label.name)
+  || github.event_name == 'issues' && endsWith(github.actor, '[bot]') && 'Cascade'
+  || github.event_name == 'issues' && 'Run'
+  || contains(github.event.comment.body || github.event.review.body, '@claude') && 'Root'
+  || 'Comment' }}
+  · #${{ github.event.issue.number || github.event.pull_request.number }}
+  ${{ github.event.issue.title || github.event.pull_request.title }}
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  team:
+    # ⚠️ THE CEILING, NOT THE GRANT. A called workflow's jobs cannot request permissions the caller
+    # did not allow — omit this block and every run dies at startup with "the nested job X is
+    # requesting … but is only allowed …". Each nested job still narrows to its own block; this is
+    # the union of what any of them asks for.
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      actions: read
+      id-token: write
+    uses: matt-whitaker/claude-team/.github/workflows/team.yml@mainline
+    with:
+      project_owner: matt-whitaker
+      project_number: "9"
+      allowed_bots: ""
+      node: false
+      browser: false
+    secrets: inherit

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -4,6 +4,7 @@ import unittest
 TEAM = (pathlib.Path(__file__).resolve().parent.parent / ".github/workflows/team.yml").read_text()
 ACTION = (pathlib.Path(__file__).resolve().parent.parent / ".github/actions/load-prompt/action.yml").read_text()
 STUB = (pathlib.Path(__file__).resolve().parent.parent / "templates/consumer-stub.yml").read_text()
+SELF = (pathlib.Path(__file__).resolve().parent.parent / ".github/workflows/claude.yml").read_text()
 
 
 class TeamWorkflow(unittest.TestCase):
@@ -89,3 +90,35 @@ class ReleasePins(unittest.TestCase):
         self.assertEqual(action_refs, {team_ref})
         self.assertEqual(prompt_default, team_ref)
         self.assertEqual(stub_ref, team_ref)
+
+
+class SelfInstall(unittest.TestCase):
+    """This repo consumes itself, and its stub is the ONE pin that must not move at release.
+
+    ReleasePins flips together on a release commit that is tagged and deliberately not merged.
+    `.github/workflows/claude.yml` lives on mainline permanently, so a `vN` written into it would
+    be a fifth pin nothing asserts — and mainline would run its own team on assets from an older
+    version of itself. A blanket mainline -> vN sweep across .github at release time is exactly
+    the plausible edit this catches."""
+
+    def test_the_self_install_tracks_mainline(self):
+        import re
+        ref = re.search(r"uses: matt-whitaker/claude-team/\.github/workflows/team\.yml@(\S+)", SELF).group(1)
+        self.assertEqual(ref, "mainline")
+
+    def test_the_inputs_are_filled_in(self):
+        self.assertNotIn("CHANGE-ME", SELF)
+        self.assertIn("project_owner: matt-whitaker", SELF)
+
+    def test_the_permissions_ceiling_survives(self):
+        # ⚠️ A called workflow cannot request permissions its caller did not grant. Trim any of
+        # these and every run dies at startup, before a job exists to report it.
+        for scope in ("contents: write", "issues: write", "pull-requests: write",
+                      "actions: read", "id-token: write"):
+            self.assertIn(scope, SELF, scope)
+
+    def test_the_triggers_live_in_the_stub(self):
+        # A called workflow's run-name is ignored and its workflow-level concurrency unsupported,
+        # so both belong here rather than upstream.
+        for key in ("on:", "issues:", "issue_comment:", "pull_request:", "run-name:", "concurrency:"):
+            self.assertIn(key, SELF, key)


### PR DESCRIPTION
`ONBOARDING.md` executed against this repo. The install is one frozen stub plus a `.claude-team/`
directory, exactly as any other consumer gets — the difference is that here the consumer and the
package are the same repository.

### The four inputs

| input | value | why |
|---|---|---|
| `project_owner` / `project_number` | `matt-whitaker` / `9` | the **Claude Team** board |
| `allowed_bots` | `""` | no dispatch App is installed, so the cascade is **dark** — a finished task will not start the next one, and the maintainer's label gesture drives everything. That is the correct starting state; flip it when the App half of step 6 happens |
| `node` | `false` | the gate is `python3 -m unittest discover -s tests`, stdlib only. Nothing to install, and no `package-lock.json` to satisfy `actions/setup-node` with |
| `browser` | `false` | nothing here renders |

### ⚠️ The pin is `mainline`, and it is the one pin that must never move

Every other consumer pins a `vN` and bumps it in a one-line PR. This one cannot. Release tooling
flips the four pins `ReleasePins` asserts — `TEAM_REF`, the two composite-action refs,
`load-prompt`'s default, the template's — on a commit that is **tagged and deliberately not
merged**. A `vN` written into this repo's own stub would therefore be a fifth pin nothing asserts
and nobody remembers, and `mainline` would end up running its own team on assets from an older
version of itself.

`SelfInstall` in `tests/test_workflow.py` asserts it, alongside the two traps the stub exists to
carry: the full `permissions:` ceiling (trim any of it and every run dies at startup, before a job
exists to report it) and the triggers, `run-name` and `concurrency` that a called workflow cannot
own.

### The overlays

`_shared.md` carries what only this repo can say: how to *read* the gate (a sandbox that is too
clean is this repo's characteristic false pass — #748), the pins that move together, `gh api`
printing its error body to stdout, `team.authenticate_git()` before network git and `team.scrub()`
before reporting it, the no-single-quote rule on schemas, and that `CLAUDE.md` is append-mostly
because its paragraphs are measured failures rather than style.

Three role overlays, each because the base has no referent here:

- **Writer** — there is no product specification and none should be created; `CLAUDE.md` plays its
  part, and the three documents divide as rules / orientation / runbook.
- **Tester** — the specification the base tells it to derive from is `CLAUDE.md`'s marked
  paragraphs plus the hook docstrings; reading the hook body to decide what to assert is the
  forbidden derivation, and the sandbox has to construct the awkward state rather than the happy
  one.
- **Researcher** — nearly every spike here is a platform question, and a claim counts as verified
  only when it was read in the host action's **source**; the drill it cannot run belongs in
  `howToSettle`, and `claude-team-example` is where a drill happens.

No `setup.sh`: there is nothing to install beyond what the runner already has.

### Labels

All fourteen exist on this repo now — the front door, the eight role stamps, the completion stamp,
and the classification set (`bug` was already there).

### ⚠️ Nothing can fire until this merges

`issues` events always run the workflow from the default branch, so silence before merge is
expected and is not a failure. Two things follow the merge: the secrets issue (filed separately —
without the model credential every routed run fails at its model step in seconds, and everything
scripted still works), and a drill on a small real issue, read by jobs, steps and `num_turns`
rather than by the tracking comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
