### PR TITLE
Publish the canonical label set with its colours

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -66,11 +66,28 @@ Nothing in the base prompts names any repo — if an overlay only restates the b
 ## 4. The labels
 
 Create them all before the first run — the front door triggers nothing without `@claude`, and a
-missing role label makes the stamp hook warn and skip:
+missing role label makes the stamp hook warn and skip.
 
-`@claude` · `@claude/architect` · `@claude/implementor` · `@claude/designer` ·
-`@claude/tester` · `@claude/writer` · `@claude/researcher` · `@claude/security` ·
-`@claude/complete` · and the classification set `epic` / `spike` / `bug` / `story` / `task`.
+[`templates/labels.json`](templates/labels.json) is the canonical set: fourteen labels with their
+colours and descriptions. Apply it rather than typing them, so a fleet reads the same way at a
+glance — the colour is doing real work on a board, where `@claude/security` in red and
+`@claude/complete` in green are how you find a run's state without opening anything:
+
+```bash
+curl -s https://raw.githubusercontent.com/matt-whitaker/claude-team/mainline/templates/labels.json \
+  | jq -c '.[]' | while read -r l; do
+      name=$(jq -r .name <<<"$l"); color=$(jq -r .color <<<"$l"); desc=$(jq -r .description <<<"$l")
+      gh label create "$name" -R <owner>/<repo> --color "$color" --description "$desc" 2>/dev/null \
+        || gh label edit "$name" -R <owner>/<repo> --color "$color" --description "$desc"
+    done
+```
+
+⚠️ **The `create || edit` pair is deliberate** — it is idempotent, so it both seeds a new consumer
+and re-syncs one whose colours have drifted. brewdocs.beer-kb was onboarded by hand before this
+file existed and ended up with every role the same purple, which is exactly the failure this
+removes.
+
+A repo may add labels of its own; nothing here removes them.
 
 ## 5. Ship it
 

--- a/templates/labels.json
+++ b/templates/labels.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "@claude",
+    "color": "c15f3c",
+    "description": "The front door \u2014 applying it starts a run, and it is spent at close"
+  },
+  {
+    "name": "@claude/architect",
+    "color": "fbca04",
+    "description": "Claude: researches and breaks down stories"
+  },
+  {
+    "name": "@claude/implementor",
+    "color": "1d76db",
+    "description": "Claude: implement an issue"
+  },
+  {
+    "name": "@claude/designer",
+    "color": "1d76db",
+    "description": "Designer \u2014 the design-system author"
+  },
+  {
+    "name": "@claude/tester",
+    "color": "0e8a16",
+    "description": "Claude: add test coverage"
+  },
+  {
+    "name": "@claude/writer",
+    "color": "5319e7",
+    "description": "Claude: update documentation"
+  },
+  {
+    "name": "@claude/researcher",
+    "color": "fbca04",
+    "description": "Claude: answers a spike and recommends, shapes nothing"
+  },
+  {
+    "name": "@claude/security",
+    "color": "b60205",
+    "description": "Claude: secure the project"
+  },
+  {
+    "name": "@claude/complete",
+    "color": "0e8a16",
+    "description": "The agent machinery finished this \u2014 swapped in for @claude at close"
+  },
+  {
+    "name": "epic",
+    "color": "be14e5",
+    "description": "A body of work spanning several stories \u2014 the maintainer's to create, never a role's"
+  },
+  {
+    "name": "spike",
+    "color": "1d76db",
+    "description": "A question the work cannot start without \u2014 answered by the Researcher, ships nothing"
+  },
+  {
+    "name": "bug",
+    "color": "d73a4a",
+    "description": "Something isn't working"
+  },
+  {
+    "name": "story",
+    "color": "0e8a16",
+    "description": "One shippable outcome, carrying its own branch and the PR that closes it"
+  },
+  {
+    "name": "task",
+    "color": "1d76db",
+    "description": "A slice of a story, with its own branch and PR"
+  }
+]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -122,3 +122,28 @@ class SelfInstall(unittest.TestCase):
         # so both belong here rather than upstream.
         for key in ("on:", "issues:", "issue_comment:", "pull_request:", "run-name:", "concurrency:"):
             self.assertIn(key, SELF, key)
+
+class CanonicalLabels(unittest.TestCase):
+    """The label set is part of the consumer contract; the doc and the data must agree."""
+
+    def setUp(self):
+        import json
+        root = pathlib.Path(__file__).resolve().parent.parent
+        self.labels = json.load(open(root / "templates/labels.json"))
+        self.onboarding = (root / "ONBOARDING.md").read_text()
+
+    def test_every_label_has_a_colour_and_a_description(self):
+        for l in self.labels:
+            self.assertRegex(l["color"], r"^[0-9a-f]{6}$", l["name"])
+            self.assertTrue(l["description"].strip(), f"{l['name']} has no description")
+
+    def test_the_roles_the_workflow_stamps_all_have_labels(self):
+        named = {l["name"] for l in self.labels}
+        for role in ("architect", "implementor", "designer", "tester", "writer",
+                     "researcher", "security", "complete"):
+            self.assertIn(f"@claude/{role}", named)
+        self.assertIn("@claude", named)
+
+    def test_onboarding_points_at_the_file_rather_than_listing_them(self):
+        self.assertIn("templates/labels.json", self.onboarding)
+


### PR DESCRIPTION
## Summary

`ONBOARDING.md` listed fourteen label names and nothing else, so every consumer invented colours. brewdocs.beer-kb — onboarded by hand — ended up with **all seven roles the same purple and all five classification labels the same green**, which defeats the point: on a board, colour is how you tell `@claude/security` from `@claude/complete` without opening anything.

- **`templates/labels.json`** is now the canonical set, colours and descriptions taken from brewdocs.beer as the reference implementation.
- **ONBOARDING step 4** points at it with an idempotent `create || edit` loop, which both seeds a new consumer and **re-syncs one that has drifted** — the second half being what kb needed.
- Three labels had no description worth copying. They have one now, including `@claude`, whose description was the single word "Claude".

## Verification

Suite **70 OK**, including three new pins: every label has a six-digit colour and a non-empty description, every role the workflow stamps has a label, and ONBOARDING references the file rather than re-listing the names.

⚠️ The description test **failed on first run** and caught `epic` and `story` shipping empty — which is the whole point of pinning it, since a silently description-less label is exactly what gets copied into the next repo.

kb has already been re-synced by hand, so it matches this file today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)