### PR TITLE
Let a task's Branch line outrank prose, so an epic cannot adopt it

### DIFF
--- a/hooks/file-sub-issues.py
+++ b/hooks/file-sub-issues.py
@@ -11,7 +11,11 @@ that read as reliable and was not: no prompt ever required it, so a run that omi
 nothing and said nothing. A task's Branch line cannot be skipped — routing reads it, so a task
 without one does not work at all — and its leading number is the story. The prose reference is
 still honoured, because it is the only anchor an EPIC has: a story's Branch line names itself,
-not its epic. See claims_parent.
+not its epic. See discover.
+
+⚠️ AND THE BRANCH LINE IS EXCLUSIVE, not merely first among equals. Unioning it with prose let an
+epic adopt its stories' TASKS, because a task's body legitimately names the epic for context. See
+discover for what that cost.
 
 A manifest is still honoured when one exists, unioned with what was discovered, so epics
 decomposed under the old contract keep working.
@@ -52,7 +56,7 @@ if manifests:
 #
 # Three markers, all required:
 #   1. the author is a Bot — the Architect creates sub-issues through the action
-#   2. the body claims this parent — see claims_parent below
+#   2. the body claims this parent — see discover below
 #   3. a number above the parent's
 #
 # The body markers alone are not enough in a repo that documents its own conventions: a
@@ -68,8 +72,6 @@ listing = team.gh_json(
     "api", "--paginate",
     f"repos/{team.REPO}/issues?state=all&sort=created&direction=desc&per_page=100",
 ) or []
-# the trailing (non-digit|end) stops `epic #412` from matching `epic #4123`
-refers = re.compile(rf"(?i)(epic|story) +#{ISSUE}([^0-9]|$)")
 
 
 def sequenced(parent: str) -> set[int]:
@@ -99,37 +101,45 @@ def sequenced(parent: str) -> set[int]:
     return {n for n in found if n > int(parent)}
 
 
-def claims_parent(body: str) -> bool:
-    """Two anchors, unioned. The Branch line is the reliable one.
-
-    ⚠️ THE PROSE REFERENCE IS NOT REQUIRED OF THE ARCHITECT ANYWHERE. Anchoring on it alone is
-    the same mistake one level up from the manifest this hook already abandoned: a model-written
-    marker that no prompt demands. Story #515's four tasks each carried both stamped lines and
-    were all bot-authored, and every filter passed except this one — so nothing was filed,
-    sub_issues came back empty, and log-to-story reported "no tasks" with nothing to signal it.
-
-    The Branch line cannot be skipped: routing itself reads it, so a task without one does not
-    work at all. Its leading number is the story.
-
-    ⚠️ It resolves STORY -> TASK ONLY. A story's own Branch line names *itself*, not its epic,
-    so an epic has nothing but the prose to go on — which is why both anchors stay. That
-    asymmetry also means this can never adopt a story as its own child: the `number > parent`
-    bound already excludes the parent itself.
-    """
-    return team.story_from_branch(team.branch_line(body)) == str(ISSUE) or bool(refers.search(body))
-
-
 def discover(parent: str) -> set[int]:
-    """Bot-authored issues, numbered above the parent, whose Branch line resolves to it."""
-    branch_of = re.compile(rf"(?i)(epic|story) +#{parent}([^0-9]|$)")
-    def claims(body: str) -> bool:
-        return team.story_from_branch(team.branch_line(body)) == str(parent) or bool(branch_of.search(body))
+    """Bot-authored issues, numbered above the parent, that claim it.
+
+    Two anchors, and they are NOT equal. The Branch line is structural — routing reads it, so a
+    task without one does not work at all — and its leading number names the story. Prose is the
+    fallback, and exists for exactly one case: an epic, which a story's Branch line can never
+    point at because it names the story itself.
+
+    ⚠️ A BRANCH LINE NAMING ANOTHER ISSUE IS AN EXCLUSIVE CLAIM. Unioning the two anchors is what
+    flattened epic #1269: a task's body legitimately says "under epic #1269" — context every
+    Architect writes — so it satisfied the epic's PROSE rule as well as its own story's BRANCH
+    rule, and the epic adopted it. Nothing in a body distinguishes "this is my parent" from "I
+    mention this", so the structural anchor has to win outright rather than merely be tried first.
+
+    ⚠️ THE TASKS WERE THEN LOST TO THEIR STORY, not merely duplicated onto the epic. The
+    one-level-down pass subtracts `children`, so a task the epic adopted is excluded from its own
+    story's set — the story ends with ZERO sub-issues, `dispatch-next.py` finds its next task
+    through `team.sub_issues(STORY)`, and the cascade stops silently with "#N has no tasks".
+
+    ⚠️ A task whose story is never discovered is now left UNPARENTED rather than mis-parented, and
+    that is the better failure by design: `sub-issue-link` is a repair kind the custodian can see
+    and fix, while mis-parentage looks correct to the sweep — the children ARE linked, just to the
+    wrong parent — so it can be neither reported nor repaired.
+    """
+    # the trailing (non-digit|end) stops `epic #412` from matching `epic #4123`
+    refers_to = re.compile(rf"(?i)(epic|story) +#{parent}([^0-9]|$)")
+
+    def claims(number: int, body: str) -> bool:
+        named = team.story_from_branch(team.branch_line(body))
+        if named and named != str(number):
+            return named == str(parent)
+        return bool(refers_to.search(body))
+
     return {
         i["number"] for i in listing
         if not i.get("pull_request")
         and i.get("number", 0) > int(parent)
         and (i.get("user") or {}).get("type") == "Bot"
-        and claims(i.get("body") or "")
+        and claims(i["number"], i.get("body") or "")
     }
 
 
@@ -147,6 +157,13 @@ if not children:
 milestone = (team.issue(ISSUE, "milestone").get("milestone") or {}).get("title") or ""
 existing = {i["number"] for i in team.sub_issues(ISSUE)}
 
+# ⚠️ What the parenting step below rejected as a pull request. `discover()` filters PRs out of the
+# issue listing, but `sequenced()` reads raw `#N` references from a Sequencing section — and a
+# story's own PR gets referenced there. Measured on #1269: `discovered ... 1289 ...`, which is the
+# story PR for #1273. It cannot be PARENTED (the step refuses it), but it was still iterated as a
+# PARENT one level down, asking the listing for children of a pull request.
+not_issues: set[int] = set()
+
 for child in sorted(children):
     if child in existing:
         print(f"#{child} already a sub-issue of #{ISSUE}")
@@ -161,6 +178,7 @@ for child in sorted(children):
         # anchor, present and future, rather than patching one of them.
         if (data or {}).get("pull_request"):
             print(f"#{child} is a pull request, not an issue — not parented.")
+            not_issues.add(child)
             continue
         cid = (data or {}).get("id")
         if cid and team.gh(
@@ -186,7 +204,7 @@ for child in sorted(children):
 # ⚠️ Exactly one level. A task has no children, so recursing further would only re-scan the same
 # listing to no purpose — and unbounded recursion over a parent-derived rule is how a cycle gets
 # built out of a convention.
-for parent in sorted(children):
+for parent in sorted(children - not_issues):
     below = discover(str(parent)) - {parent} - children
     if not below:
         continue

--- a/tests/test_file_sub_issues.py
+++ b/tests/test_file_sub_issues.py
@@ -60,5 +60,58 @@ class FileSubIssues(HookCase):
         self.assertIn("pull request, not an issue", r.stdout)
 
 
+# ── #23: an epic's run must not adopt its stories' tasks ────────────────────────────────
+#
+# Numbers and bodies are the brewdocs.beer#1269 incident: story #1290 with tasks #1291 and
+# #1292, each carrying prose that legitimately names the epic. The epic's Sequencing section
+# names only the story.
+EPIC_1269 = "## Sequencing\n\n1. #1290 — the guide.\n"
+NESTED = [
+    {"number": 1290, "user": {"type": "Bot"},
+     "body": "**Branch: `1290-guide-backup`**\n\nA story under epic #1269."},
+    {"number": 1291, "user": {"type": "Bot"},
+     "body": "**Branch: `1290-guide-backup`**\n**Role: writer**\n\n"
+             "Story #1290, under epic #1269. Follows story #1270."},
+    {"number": 1292, "user": {"type": "Bot"},
+     "body": "**Branch: `1290-guide-backup`**\n**Role: implementor**\n\n"
+             "Part of epic #1269; already live, from epic #947."},
+]
+NESTED_ISSUES = {
+    "1269": {"body": EPIC_1269, "kids": []},
+    "1290": {"body": NESTED[0]["body"], "kids": []},
+    "1291": {"body": NESTED[1]["body"]},
+    "1292": {"body": NESTED[2]["body"]},
+}
+
+
+class Nesting(HookCase):
+    def file(self, issue):
+        return self.run_hook("file-sub-issues.py", {
+            "ISSUE": issue, "GH_TOKEN": "t",
+            "STUB_ISSUES": NESTED_ISSUES, "STUB_LISTING": NESTED,
+        })
+
+    def parented(self, r):
+        pairs = []
+        for c in self.calls_matching(r, "sub_issues", "POST"):
+            url = next(a for a in c["args"] if "/sub_issues" in a)
+            value = next(a for a in c["args"] if a.startswith("sub_issue_id="))
+            pairs.append((url.split("/")[-2], value.split("=")[-1]))
+        return pairs
+
+    def test_the_story_reaches_its_epic(self):
+        self.assertIn(("1269", "12900"), self.parented(self.file("1269")))
+
+    def test_the_epic_does_not_adopt_its_storys_tasks(self):
+        pairs = self.parented(self.file("1269"))
+        self.assertNotIn(("1269", "12910"), pairs)
+        self.assertNotIn(("1269", "12920"), pairs)
+
+    def test_the_tasks_reach_their_own_story(self):
+        pairs = self.parented(self.file("1269"))
+        self.assertIn(("1290", "12910"), pairs)
+        self.assertIn(("1290", "12920"), pairs)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #23.

`file-sub-issues.py` parented every discovered child to the triggering issue, so an Architect run on an epic swept that epic's stories *and* their tasks onto the epic.

The cause is narrower than "no notion of nesting". `discover()` **unioned** two anchors — a `Branch:` line resolving to the parent, and a prose `epic #N` / `story #N` reference — and a task satisfies both at once. Its Branch line names its story, and its body legitimately says "under epic #1269", which is context every Architect writes. Nothing in a body distinguishes *"this is my parent"* from *"I mention this"*.

⚠️ **The tasks were then lost to their story, not merely duplicated onto the epic.** The one-level-down pass subtracts `children`, so a task the epic had adopted was excluded from its own story's set. The story ended with **zero** sub-issues, and `dispatch-next.py` finds the next task through `team.sub_issues(STORY)` — so the cascade stopped with *"#N has no tasks — nothing to dispatch"* and nothing anywhere said why. Issue #23 records the symptom; this is the mechanism behind it.

### The rule

The Branch line is now **exclusive**. When it names an issue other than the one carrying it, that issue is the parent and prose is never consulted. Only an issue whose Branch line names *itself* — a story — or carries none falls through to prose, which is the epic case and the only case prose was ever needed for.

⚠️ A task whose story is never discovered is now left **unparented** rather than **mis-parented**, and that is the better failure by design: `sub-issue-link` is a repair kind the custodian can see and fix, while mis-parentage looks correct to the sweep — the children *are* linked, just to the wrong parent — so it can be neither reported nor repaired.

### Also in this change

- **`claims_parent` and its module-level `refers` deleted.** Dead since `discover()` took a parent argument and grew its own copy. A dead duplicate of live logic is how the two drift, and it is part of why this survived.
- **A pull request can no longer be iterated as a parent.** Defect 2 in the issue was already half-handled: PRs are rejected at the parenting step, with a test covering it, so #1289 could never actually have been parented. What remained is that it still entered `children` and was passed to `discover()` one level down. The parenting step now remembers what it rejected.

## Verification

- `python3 -m unittest discover -s tests` — **73 tests, OK** (was 70).
- `python3 -m compileall -q hooks` — clean.
- The three new cases in `tests/test_file_sub_issues.py` are built from the brewdocs.beer#1269 numbers and **were written before the fix and observed failing**: the epic adopted `1290`, `1291` and `1292` alike, and story `1290` received nothing. They pass now, with the tasks landing on their story.
- Every scripted find-and-replace in this change was count-asserted.

## Not in scope, and deliberately left

Issue #23 lists four suggested fixes. This is 1 and 2. The other two are follow-ups rather than omissions:

- An explicit `Parent: #N` line the Architect writes and the hook keys on, which would remove the prose ambiguity permanently. Needs an Architect prompt change.
- A `re-parent` repair kind, so mis-parentage becomes something the custodian can name. Needs `schemas/repairs.json`, `apply-repairs.py` and the custodian prompt together.

⚠️ **This stops new flattening; it does not repair existing children.** Anything already mis-parented in a consuming repo stays where it is, and needs either the `re-parent` kind above or a hand fix.

## What could not be determined

This is proven by the reproduction, not by a live run — an engine change of this shape cannot be exercised before merge, since `issues` events always run the workflow from the default branch. Whether the mainline Architect path behaves identically to the harness's stubbed `team` is therefore unverified here, as it is for every hook change in this repo.

The issue and this PR still need adding to the board by hand: this session has no `gh` CLI, and the GitHub MCP server exposes no Projects v2 tools.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_