### PR TITLE
Say when a Sequencing section parses to nothing, and stop the prompt causing it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,31 @@ must be stated where it can be seen:
   start the next wave; a task the section forgot is appended in derived `(phase, issue number)`
   order rather than stranded, and with no section at all tasks run one at a time in that derived
   order. The same section is what the human reads when driving by hand.
+  - ⚠️ **A SECTION THAT PARSES TO NOTHING IS NOT THE SAME AS NO SECTION, AND FOR ONE RELEASE BOTH
+    WERE SILENT.** `sequencing_refs()` only reads refs from lines that *start* with a number, so a
+    section written as prose — *"Its tasks run in order: writer, then implementor, then tester"* —
+    reads correctly to a human, satisfies any check looking for the heading, and carries no
+    instruction at all. A ref naming something outside the story already warned; a section naming
+    **nothing** did not, so the loud signal went to the smaller problem. Both callers now say so,
+    and the fallback to derived order is deliberately kept — falling back is right, doing it in
+    silence is what cost the diagnosis.
+  - ⚠️ **THE ROOT CAUSE WAS THE ARCHITECT PROMPT'S OWN WORKED EXAMPLE.** It demonstrated
+    `**Sequencing.** Its tasks run in order: #606, then #607, then #608.` — which matches the
+    heading, puts its refs on the heading line, and parses to zero waves. Two sibling stories
+    shipped that form with roles instead of numbers and both ran on derived order. The parser was
+    never wrong; the instruction was. ⚠️ A test now parses every Sequencing example in the prompt,
+    because prose review had already passed this twice.
+  - ⚠️ **THE NUMBERED FORM IS CONTAINMENT, NOT DOCUMENTATION**, which is the reason this is worth
+    fixing rather than filing as cosmetic. A task the section forgets is appended *after* the
+    listed waves, deliberately — so a task mis-parented onto the wrong story runs last. With the
+    section inert everything falls to derived order, that foreign task sorts by its role phase, and
+    a stray `writer` dispatches **ahead of the story's own implementor**. Measured on a consumer at
+    `v1.1`: the prose form is what turned a filing error into a dispatch-order error.
+  - ⚠️ **AN EPIC'S SECTION IS PROSE AND THAT IS CORRECT** — two forms, two parsers, and one looks
+    exactly like the trap. `file-sub-issues.py` takes any `#N` on any line of an epic's section, so
+    the inline form is legitimate there; the identical form on a *story* is the defect above. The
+    custodial check is therefore scoped behind the epic/spike return, and a test pins both so
+    nobody harmonises one example to match the other.
   - ⚠️ **THE FIRST WAVE NEEDS ITS OWN IGNITION, and for one release it had none.** The hook chains
     task N to task N+1 from the authors job, so a story could be *continued* but never *begun* —
     the maintainer still hand-labelled task 1, which is the gesture the cascade existed to remove

--- a/hooks/custodial-sweep.py
+++ b/hooks/custodial-sweep.py
@@ -57,7 +57,28 @@ def check_deliverable() -> None:
         print(f"#{ISSUE} is {'an epic' if KIND == 'epic' else 'a spike'} — no Branch line expected.")
         return
 
-    if team.branch_line(team.issue_body(ISSUE)):
+    body = team.issue_body(ISSUE)
+
+    # ⚠️ A SECTION THAT PARSES TO NOTHING IS CAUGHT HERE, NOT AT DISPATCH. `dispatch-next.py`
+    # warns too, but only when someone dispatches — which may be days later, or never, and by
+    # then nobody is watching the run that caused it. Here it lands on the Architect run that
+    # wrote it, while a human is still looking.
+    #
+    # ⚠️ WARN, DO NOT FAIL. Derived order is a working fallback, so the story is not broken the
+    # way a missing Branch line breaks it — that one fails because nothing downstream can work at
+    # all. Failing here would be disproportionate, and the fallback is deliberately kept.
+    #
+    # ⚠️ Not applied to an epic: its section is read by `file-sub-issues.py`, whose parser takes
+    # any `#N` on any line in the section, so the prose form is legitimate there. Two parsers,
+    # two strictnesses — which is exactly why this check sits behind the epic/spike return above.
+    if team.sequencing_refs(body) == []:
+        team.warn(
+            f"#{ISSUE} has a Sequencing section that names no numbered refs, so dispatch will "
+            "fall back to derived order. Write it as numbered lines carrying #refs — that form "
+            "is also what keeps a mis-parented task running last instead of jumping the queue."
+        )
+
+    if team.branch_line(body):
         print(f"#{ISSUE} carries its Branch line — the Architect delivered.")
         return
 

--- a/hooks/dispatch-next.py
+++ b/hooks/dispatch-next.py
@@ -98,32 +98,45 @@ def derived_order() -> list[int]:
 
 
 def sequencing_waves(body: str) -> list[list[int]]:
-    """Waves from the Architect's section; the derived order, one task per wave, without one."""
-    match = re.search(r"(?im)^(?:#{2,4}\s*sequencing\b|\*\*sequencing[.:]?\*\*)", body)
+    """Waves from the Architect's section; the derived order, one task per wave, without one.
+
+    ⚠️ A SECTION THAT PARSES TO NOTHING MUST SAY SO. Falling back to derived order is correct and
+    stays — what cost the diagnosis in #28 was doing it in silence. A near-miss ref already warns;
+    a section naming nothing at all did not, so the loudest signal went to the smaller problem.
+
+    ⚠️ It is not cosmetic, because the numbered form is the containment for a *different* defect.
+    A task the section forgets is appended after the listed waves, deliberately — so a
+    mis-parented foreign task runs last. With the section inert, everything falls to derived
+    order, that task sorts by its role phase, and a foreign `writer` dispatches ahead of the
+    story's own implementor. Measured on a consumer at `v1.1`: a filing error became a
+    dispatch-order error precisely because the section was prose.
+    """
+    parsed = team.sequencing_refs(body)
+    if parsed is None:
+        return [[n] for n in derived_order()]
+    if not parsed:
+        team.warn(
+            f"#{STORY} has a Sequencing section but no numbered refs — falling back to derived "
+            "order. The format is numbered lines carrying #refs; prose naming roles rather than "
+            "issue numbers parses to nothing, and a mis-parented task then jumps the queue "
+            "instead of running last."
+        )
+    seen: set[int] = set()
     waves: list[list[int]] = []
-    if match:
-        seen: set[int] = set()
-        for line in body[match.end():].splitlines():
-            if re.match(r"^#{1,6}\s", line):
-                break
-            if not re.match(r"^\s*\d+[.)]", line):
-                continue
-            refs = [int(n) for n in re.findall(r"#(\d+)", line)]
-            wave = []
-            for n in refs:
-                if n not in by_number:
-                    team.warn(f"sequencing names #{n}, which is not one of #{STORY}'s tasks — dropped.")
-                elif n not in seen:
-                    seen.add(n)
-                    wave.append(n)
-            if wave:
-                waves.append(wave)
-        # ⚠️ A task the section forgot is appended, never stranded.
-        for n in derived_order():
-            if n not in seen:
-                waves.append([n])
-    if not waves:
-        waves = [[n] for n in derived_order()]
+    for refs in parsed:
+        wave = []
+        for n in refs:
+            if n not in by_number:
+                team.warn(f"sequencing names #{n}, which is not one of #{STORY}'s tasks — dropped.")
+            elif n not in seen:
+                seen.add(n)
+                wave.append(n)
+        if wave:
+            waves.append(wave)
+    # ⚠️ A task the section forgot is appended, never stranded.
+    for n in derived_order():
+        if n not in seen:
+            waves.append([n])
     return waves
 
 

--- a/hooks/team.py
+++ b/hooks/team.py
@@ -185,6 +185,48 @@ def role_stamp(body: str) -> str:
     return found.group(1).lower() if found else ""
 
 
+_SEQ_HEADING = re.compile(r"(?im)^(?:#{2,4}\s*sequencing\b|\*\*sequencing[.:]?\*\*)")
+
+
+def sequencing_refs(body: str) -> list[list[int]] | None:
+    """The Architect's `Sequencing` section, parsed to waves of raw issue numbers.
+
+    Three outcomes, and keeping them distinct is the whole point:
+
+      None  no section at all — legitimate, documented, and the caller falls back silently
+      []    a section IS present and yields nothing a hook can act on
+      [[…]] one list per numbered line, in order
+
+    ⚠️ `[]` AND `None` ARE NOT THE SAME THING, and collapsing them is what made #28 silent. A
+    section naming a ref outside the story already warns; a section naming *nothing* did not, so
+    an Architect could write something that reads correctly to a human, satisfies any check
+    looking for the heading, and carries no instruction at all — with the run reporting nothing.
+
+    ⚠️ THE PROMPT'S OWN WORKED EXAMPLE PRODUCED `[]`. `**Sequencing.** Its tasks run in order:
+    #606, then #607, then #608.` matches the heading, puts its refs on the heading line, and so
+    parses to zero waves — the refs are right there and unreachable. Two sibling stories shipped
+    that form verbatim minus the numbers. The parser is not what was wrong; the instruction was.
+
+    ⚠️ Parsing only — no validation. Whether a ref is one of the story's tasks is the caller's
+    question, because the two callers want different answers: dispatch drops a foreign ref with a
+    warning, while the custodial check only asks whether the section says anything at all. One
+    parser, so they cannot disagree about what a section *is*.
+    """
+    match = _SEQ_HEADING.search(body)
+    if not match:
+        return None
+    waves: list[list[int]] = []
+    for line in body[match.end():].splitlines():
+        if re.match(r"^#{1,6}\s", line):
+            break
+        if not re.match(r"^\s*\d+[.)]", line):
+            continue
+        refs = [int(n) for n in re.findall(r"#(\d+)", line)]
+        if refs:
+            waves.append(refs)
+    return waves
+
+
 EPIC_LABEL = "epic"
 SPIKE_LABEL = "spike"
 BUG_LABEL = "bug"

--- a/prompts/architect.md
+++ b/prompts/architect.md
@@ -167,11 +167,25 @@ roles' territory, that is a sign it is two tasks.
 
 ⚠️ **A story's tasks ARE sequenced — that is the default, and the opposite of the story rule.**
 Stories are independent unless the epic says otherwise; a story's tasks are ordered unless you
-say otherwise. Say so in the story body, so nobody has to infer it from the numbering:
+say otherwise. Say so in the story body, in the **same numbered form** as above:
 
 ```
-**Sequencing.** Its tasks run in order: #606, then #607, then #608.
+### Sequencing
+1. #606
+2. #607
+3. #608
 ```
+
+⚠️ **NEVER AS PROSE, AND THIS EXAMPLE USED TO BE PROSE.** `**Sequencing.** Its tasks run in
+order: #606, then #607, then #608.` reads perfectly and parses to **nothing**: the heading
+matches, the refs sit on the heading line, and `dispatch-next.py` only reads refs from lines
+that *start* with a number. Two sibling stories shipped that form with roles instead of numbers
+— *"writer, then implementor, then tester"* — and both silently ran on derived order.
+
+⚠️ **The numbered form is not documentation, it is containment.** A task the section forgets is
+appended *after* the listed waves. So when a task is mis-parented onto the wrong story, the
+numbered form makes it run last; with the section inert, it sorts by role phase and can dispatch
+*ahead* of the story's own work. Prose turns a filing error into a dispatch-order error.
 
 ⚠️ **Create tasks in the order they should be run.** That order is read, not just described:
 a hook lists the story's tasks by `(phase, issue number)` and names the next one to trigger,

--- a/tests/stub_team.py
+++ b/tests/stub_team.py
@@ -19,6 +19,7 @@ GH_TOKEN = os.environ.get("GH_TOKEN", "")
 branch_line = _real.branch_line
 role_stamp = _real.role_stamp
 story_from_branch = _real.story_from_branch
+sequencing_refs = _real.sequencing_refs
 titled_epic = _real.titled_epic
 titled_spike = _real.titled_spike
 titled_bug = _real.titled_bug

--- a/tests/test_custodial_sweep.py
+++ b/tests/test_custodial_sweep.py
@@ -1,0 +1,41 @@
+import unittest
+from harness import HookCase
+
+GOOD = "**Branch: `10-thing`**\n\n### Sequencing\n1. #11\n2. #12\n"
+INERT = "**Branch: `10-thing`**\n\n### Sequencing\n\nIts tasks run in order: writer, then tester.\n"
+NO_SECTION = "**Branch: `10-thing`**\n"
+
+
+class Deliverable(HookCase):
+    def sweep(self, body, role="architect", kind="story"):
+        return self.run_hook("custodial-sweep.py", {
+            "MODE": "deliverable", "ISSUE": "10", "ROLE": role, "KIND": kind,
+            "GH_TOKEN": "t", "STUB_ISSUES": {"10": {"body": body}}})
+
+    def test_an_inert_sequencing_section_is_reported_on_the_architect_run(self):
+        r = self.sweep(INERT)
+        self.assertIn("names no numbered refs", r.stderr + r.stdout)
+
+    def test_it_warns_rather_than_failing_because_the_fallback_works(self):
+        self.assertEqual(self.sweep(INERT).returncode, 0)
+
+    def test_a_good_section_is_silent(self):
+        self.assertNotIn("names no numbered refs", self.sweep(GOOD).stderr + self.sweep(GOOD).stdout)
+
+    def test_no_section_is_silent(self):
+        r = self.sweep(NO_SECTION)
+        self.assertNotIn("names no numbered refs", r.stderr + r.stdout)
+
+    def test_an_epic_is_exempt_because_its_section_has_a_looser_parser(self):
+        # file-sub-issues reads any #N on any line of an epic's section, so prose is valid there
+        r = self.sweep("### Sequencing\n\nStories: #11 then #12.\n", kind="epic")
+        self.assertNotIn("names no numbered refs", r.stderr + r.stdout)
+
+    def test_a_missing_branch_line_still_fails_the_run(self):
+        r = self.sweep("### Sequencing\n1. #11\n")
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("no Branch line", r.stderr + r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dispatch_next.py
+++ b/tests/test_dispatch_next.py
@@ -69,5 +69,45 @@ class DispatchNext(HookCase):
         self.assertNotIn("::error::", r.stdout)
 
 
+# ── #28: a section that parses to zero refs must say so ─────────────────────────────────
+PROSE = "### Sequencing\n\nIts tasks run in order: writer, then implementor, then tester.\n"
+HEADING_LINE = "**Sequencing.** Its tasks run in order: #11, then #12, then #14.\n"
+
+
+class InertSequencing(HookCase):
+    def dispatch(self, body, tasks=TASKS4):
+        return self.run_hook("dispatch-next.py", {
+            "STORY": "10", "GH_TOKEN": "t", "STUB_ISSUES": issues(body, tasks)})
+
+    def dispatched(self, r):
+        return [c["args"][1].split("/")[-2] for c in self.calls_matching(r, "labels")]
+
+    def test_prose_section_warns_rather_than_falling_back_in_silence(self):
+        r = self.dispatch(PROSE)
+        self.assertIn("Sequencing section but no numbered refs", r.stderr + r.stdout)
+
+    def test_refs_on_the_heading_line_are_unreachable_and_warn(self):
+        # the form the Architect prompt used to demonstrate: refs present, none parseable
+        r = self.dispatch(HEADING_LINE)
+        self.assertIn("Sequencing section but no numbered refs", r.stderr + r.stdout)
+
+    def test_the_fallback_itself_is_kept(self):
+        self.assertEqual(self.dispatched(self.dispatch(PROSE)), ["12"])
+
+    def test_no_section_at_all_stays_silent(self):
+        # absent is legitimate and documented — only a section that says nothing is a problem
+        r = self.dispatch("plain body")
+        self.assertNotIn("Sequencing section but no numbered refs", r.stderr + r.stdout)
+
+    def test_a_good_section_stays_silent(self):
+        r = self.dispatch(BODY_WAVES)
+        self.assertNotIn("Sequencing section but no numbered refs", r.stderr + r.stdout)
+
+    def test_a_foreign_ref_still_warns_on_its_own_terms(self):
+        r = self.dispatch("### Sequencing\n1. #999\n2. #12\n")
+        self.assertIn("#999, which is not one of #10's tasks", r.stderr + r.stdout)
+        self.assertNotIn("no numbered refs", r.stderr + r.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -47,6 +47,76 @@ class Scrub(unittest.TestCase):
         self.assertEqual(team.scrub("abc"), "abc")
 
 
+class SequencingRefs(unittest.TestCase):
+    def test_no_section_is_none_not_empty(self):
+        self.assertIsNone(team.sequencing_refs("plain body"))
+
+    def test_a_section_naming_nothing_is_empty_not_none(self):
+        self.assertEqual(team.sequencing_refs("### Sequencing\n\nwriter, then tester.\n"), [])
+
+    def test_numbered_lines_become_waves(self):
+        self.assertEqual(
+            team.sequencing_refs("### Sequencing\n1. #11\n2. #12, #13\n"), [[11], [12, 13]])
+
+    def test_refs_on_the_heading_line_are_unreachable(self):
+        self.assertEqual(team.sequencing_refs("**Sequencing.** In order: #606, then #607."), [])
+
+    def test_it_stops_at_the_next_heading(self):
+        body = "### Sequencing\n1. #11\n\n## Out of scope\n2. #999\n"
+        self.assertEqual(team.sequencing_refs(body), [[11]])
+
+
+class ArchitectPromptExamplesParse(unittest.TestCase):
+    """⚠️ THE PROMPT'S OWN EXAMPLE WAS THE ROOT CAUSE OF #28.
+
+    `**Sequencing.** Its tasks run in order: #606, then #607, then #608.` shipped as a worked
+    example, matched the heading, and parsed to zero waves — so an Architect following the prompt
+    exactly produced an inert section. A prompt that demonstrates a form the reader cannot parse
+    is worse than one that says nothing, and prose alone could never have caught it.
+    """
+
+    def setUp(self):
+        root = pathlib.Path(__file__).resolve().parent.parent
+        self.prompt = (root / "prompts/architect.md").read_text()
+
+    def examples(self):
+        import re
+        blocks = re.findall(r"```\n(.*?)```", self.prompt, re.S)
+        return [b for b in blocks if re.search(r"(?i)sequencing", b)]
+
+    def test_every_story_form_example_parses_to_at_least_one_wave(self):
+        """The `### Sequencing` block form, which `dispatch-next.py` reads."""
+        story_form = [b for b in self.examples() if b.lstrip().startswith("### Sequencing")]
+        self.assertTrue(story_form, "no story-form Sequencing example in the Architect prompt")
+        for block in story_form:
+            with self.subTest(block=block.strip()[:60]):
+                self.assertTrue(
+                    team.sequencing_refs(block),
+                    "this example parses to nothing a hook can act on")
+
+    def test_the_epic_form_is_prose_and_that_is_correct(self):
+        """⚠️ TWO FORMS, TWO PARSERS, AND ONE OF THEM LOOKS LIKE THE TRAP.
+
+        An epic's section is read by `file-sub-issues.py`, which takes any `#N` on any line —
+        so the inline `**Sequencing.**` prose form is legitimate there. The identical form on a
+        STORY is the #28 defect, because `dispatch-next.py` only reads refs from lines starting
+        with a number. Pinned so nobody 'fixes' the epic example to match the story one, or the
+        reverse.
+        """
+        import re
+        epic_form = [b for b in self.examples() if b.lstrip().startswith("**Sequencing.**")]
+        self.assertTrue(epic_form, "no epic-form Sequencing example in the Architect prompt")
+        for block in epic_form:
+            with self.subTest(block=block.strip()[:60]):
+                self.assertEqual(team.sequencing_refs(block), [],
+                                 "epic form is prose — inert to the story parser by design")
+                self.assertTrue(re.findall(r"#(\d+)", block),
+                                "an epic's section still has to name its stories")
+
+    def test_the_prose_form_is_named_as_forbidden(self):
+        self.assertIn("NEVER AS PROSE", self.prompt)
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Summary

Closes #28.

A `### Sequencing` section written as prose yields no waves and falls through to derived order in
silence. A ref naming something outside the story already warned; a section naming **nothing** did
not — so the loud signal went to the smaller problem.

⚠️ **The root cause was the Architect prompt's own worked example.** It demonstrated:

```
**Sequencing.** Its tasks run in order: #606, then #607, then #608.
```

That matches the heading regex, puts its refs on the heading line, and parses to **zero waves** —
the refs are right there and unreachable. The two sibling stories that shipped an inert section
were following the prompt exactly, with roles in place of the numbers. The parser was never wrong;
the instruction was. The example is now the numbered form, with the prose form named as forbidden
and the reason attached.

## Why it isn't cosmetic

The numbered form is **containment for a different defect**, as #28 sets out. A task the section
forgets is appended *after* the listed waves, deliberately — so a task mis-parented onto the wrong
story runs last. With the section inert, everything falls to derived order, the foreign task sorts
by its role phase, and a stray `writer` dispatches **ahead of the story's own implementor**. Prose
is what turned a filing error into a dispatch-order error.

## What changed

- **`team.sequencing_refs()`** — parsing moves to a shared pure helper returning `None` for *no
  section* and `[]` for *a section that says nothing*. That distinction is the whole fix; collapsing
  it is what made this silent.
  It **parses and does not validate**, because the two callers want different answers: dispatch
  drops a foreign ref with a warning, the custodial check only asks whether the section says
  anything at all. One parser, so they cannot disagree about what a section *is*.
- **`dispatch-next.py`** — warns when it falls back. ⚠️ **The fallback itself is kept**, per the
  issue: falling back is right, doing it in silence is what cost the diagnosis.
- **`custodial-sweep.py`** — warns on the **Architect run that wrote it**, which is days earlier
  than dispatch and while a human is still watching. Warns rather than fails: derived order works,
  unlike a missing `Branch:` line, which breaks everything downstream and still fails.
- **`prompts/architect.md`** — the worked example fixed; the two contradictory instructions
  reconciled.
- **`CLAUDE.md`** — the trap, its measurement, and the containment argument.

## ⚠️ An epic's section stays prose, and a test pins it

Two forms, two parsers, and one looks exactly like the trap. `file-sub-issues.py` reads any `#N` on
any line of an **epic's** section, so the inline form is legitimate there; the identical form on a
**story** is this defect. The custodial check therefore sits behind the epic/spike return, and a
test asserts the epic example parses to `[]` under the story parser *and still carries refs* — so
nobody harmonises one example to match the other in either direction.

## Verification

`python3 -m unittest discover -s tests` — **93 tests, OK** (up from 73). The new cases fail against
the previous hook.

⚠️ **A test now parses every Sequencing example in the Architect prompt against the parser that
reads it.** Prose review had already passed the broken example twice, so a machine check is the
only thing that would have caught it. It earned its keep immediately: it flagged a second example
on the first run — correctly, since that one was the epic form, which is why the test distinguishes
the two rather than collapsing them.

New coverage: prose section warns; refs-on-the-heading-line warns; the fallback still dispatches;
no section at all stays silent; a good section stays silent; a foreign ref still warns on its own
terms and *doesn't* trigger the new one. Plus a first `tests/test_custodial_sweep.py`, which had no
tests at all.

## Filed separately

The adjacent `log-to-story.py` wording defect #28 mentions is filed as its own issue rather than
swept in — confirmed at `hooks/log-to-story.py:94`, which says *"authors, then tests, then docs"*
while `phase()` at line 50 is `{"writer": 1, "tester": 3}`, default `2`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_