### PR TITLE
Document the inputs and secrets in the README, and pin the table to the workflow

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -111,6 +111,11 @@ Secrets never pass through a session. File an issue on the target listing what t
   role's OIDC trust policy must also admit the new repo's `sub` claim — the secret alone is
   not enough).
 
+⚠️ **Link the README's *Inputs and secrets* table in that issue rather than restating it.** It
+carries what each item buys, what breaks without it, and where to obtain it — and the three that
+need more than a secret pasted. Two copies of this list is how they drift, and the copy a
+maintainer follows is the one that has to be right.
+
 ## 7. The drill — what proves it
 
 After merge and the required secret: file a small **real** issue (a genuine question or task —

--- a/README.md
+++ b/README.md
@@ -85,5 +85,61 @@ does for any consumer, so a green delegate is not evidence that a prompt change 
 Nothing in this package names a consuming repo, its branches, its gate or its packages — anything
 that does belongs in your overlay.
 
+## Inputs and secrets
+
+Two kinds of configuration: **inputs** written into your stub, and **secrets** the maintainer
+pastes. ⚠️ Only one secret is required. Each of the others buys exactly one feature, and a run
+stays green without them — so a missing optional secret shows up as a feature that quietly does
+not happen, never as a failure.
+
+### Inputs — in your stub
+
+| input | required | where it comes from |
+|---|---|---|
+| `project_owner` | yes | the board's URL — the user or org that owns it |
+| `project_number` | yes | the board's URL, `…/projects/<N>` |
+| `allowed_bots` | no | the dispatch App's login, `<app-slug>[bot]`. Empty admits none |
+| `node` | no | your call — `true` runs `npm ci` before author runs |
+| `browser` | no | your call — `true` installs the Playwright chromium |
+
+⚠️ Name the App in `allowed_bots` **explicitly**. A wildcard lets any external App invoke the
+action with a prompt it controls.
+
+### Secrets — *Settings → Secrets and variables → Actions*
+
+| secret | enables | without it | where to get it |
+|---|---|---|---|
+| **`CLAUDE_CODE_OAUTH_TOKEN`**<br>⚠️ **required** | every model step, all seven roles | every routed run fails env validation in seconds; the whole scripted half still works | `claude setup-token`. Issuing a new one does not revoke tokens other repos hold |
+| `PROJECTS_TOKEN` | board placement and the Status column | a warning; the issue never reaches the board | a **classic** PAT, *Settings → Developer settings → Tokens (classic)*, scopes `project` + `read:org` |
+| `DISPATCH_APP_ID` | the cascade — the next task starts itself | cascade dark; every task labelled by hand | the App's settings page |
+| `DISPATCH_APP_PRIVATE_KEY` | ″ | ″ | generate on that same page; paste the whole `.pem` |
+| `AWS_TRANSCRIPTS_ROLE` | transcript archival to S3 | capture steps skip cleanly | the IAM role's ARN |
+| `AWS_TRANSCRIPTS_BUCKET` | ″ | ″ | the S3 bucket name |
+
+`GITHUB_TOKEN` is ambient and needs no setup. ⚠️ Its deliberate property is that events raised
+with it **start no workflow runs** — one of the three loop guards.
+
+### One repository variable
+
+`AGENT_TRANSCRIPTS` — the *Variables* tab of that same page, and the on/off switch for transcript
+capture.
+
+### ⚠️ Three of these are more than a secret
+
+Pasting the secret and stopping is the commonest install failure, and it is silent.
+
+- **The cascade needs three things**: both `DISPATCH_APP_*` secrets, the App **installed on this
+  repository**, and its login in `allowed_bots`. A missing install shows as a 404 on
+  `get-a-repository-installation-for-the-authenticated-app` — authenticated as the App, not
+  installed here.
+- **Transcript capture needs four**: both AWS secrets, the `AGENT_TRANSCRIPTS` variable, and the
+  IAM role's OIDC trust policy admitting this repo's `sub` claim.
+- **`PROJECTS_TOKEN` cannot be fine-grained.** Those cannot reach user-owned Projects v2 at all,
+  and the failure reads as an unreachable project rather than a bad token.
+
+⚠️ The stub passes `secrets: inherit` and the workflow declares no `secrets:` contract, so every
+repository secret is visible to these jobs. Adding one needs no workflow edit — and the workflow
+cannot narrow what it receives.
+
 See [`CLAUDE.md`](CLAUDE.md) for the design decisions, the platform constraints they work
 around, and the failures that shaped them.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -65,6 +65,62 @@ class TeamWorkflow(unittest.TestCase):
                                  f"comment inside if block at line {j+1}")
 
 
+class ReadmeDocumentsEveryInput(unittest.TestCase):
+    """⚠️ THE README TABLE IS A SECOND COPY OF THE WORKFLOW'S CONTRACT, so it drifts by default.
+
+    A consumer reads it to decide what to paste. A secret the workflow starts consuming and the
+    table never mentions is a feature nobody knows to enable — and every optional secret here
+    fails *silently*, so nothing else would ever surface the omission.
+
+    Both directions, because each has its own failure: undocumented means a feature nobody
+    switches on, invented means a maintainer hunting for a secret that does nothing.
+    """
+
+    def setUp(self):
+        import re
+        root = pathlib.Path(__file__).resolve().parent.parent
+        self.readme = (root / "README.md").read_text()
+        self.secrets = set(re.findall(r"secrets\.([A-Z_]+)", TEAM)) - {"GITHUB_TOKEN"}
+        self.vars = set(re.findall(r"vars\.([A-Z_]+)", TEAM))
+        self.inputs = set(re.findall(r"^      ([a-z_]+):$", TEAM.split("jobs:")[0], re.M))
+        self.assertIn("## Inputs and secrets", self.readme, "the reference section is gone")
+        self.section = self.readme.split("## Inputs and secrets")[1]
+
+    def test_every_secret_the_workflow_reads_is_documented(self):
+        self.assertTrue(self.secrets)
+        for name in sorted(self.secrets):
+            with self.subTest(secret=name):
+                self.assertTrue(f"`{name}`" in self.readme,
+                                f"{name} is read by team.yml but absent from the README table")
+
+    def test_every_repository_variable_is_documented(self):
+        self.assertTrue(self.vars)
+        for name in sorted(self.vars):
+            with self.subTest(var=name):
+                self.assertTrue(f"`{name}`" in self.readme,
+                                f"{name} is read by team.yml but absent from the README table")
+
+    def test_every_workflow_input_is_documented(self):
+        self.assertTrue(self.inputs)
+        for name in sorted(self.inputs):
+            with self.subTest(input=name):
+                self.assertTrue(f"`{name}`" in self.readme,
+                                f"{name} is a workflow input but absent from the README table")
+
+    def test_the_table_invents_nothing(self):
+        import re
+        known = self.secrets | self.vars | {"GITHUB_TOKEN"}
+        for name in sorted(set(re.findall(r"`([A-Z][A-Z_]{3,})`", self.section))):
+            with self.subTest(named=name):
+                self.assertTrue(name in known,
+                                f"README names {name}, which team.yml never reads")
+
+    def test_onboarding_points_at_the_table_rather_than_restating_it(self):
+        root = pathlib.Path(__file__).resolve().parent.parent
+        onboarding = (root / "ONBOARDING.md").read_text()
+        self.assertIn("Inputs and secrets", onboarding)
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Summary

Closes #33.

No single place said what configuration this package takes, what each item buys, or **where to
obtain it**. `ONBOARDING.md` lists the secrets by consequence, but it is an install runbook — it
tells an agent what issue to file, not a reader what the system consumes. The full picture only
existed by grepping `team.yml`, the hooks and the capture action.

**`README.md`** gains an *Inputs and secrets* section: five secrets, one repository **variable**,
five workflow inputs. Each row carries what it enables, what happens without it, and a short note
on where it comes from — the board URL, `claude setup-token`, a classic PAT, the App's settings
page, the IAM role ARN.

**`ONBOARDING.md`** points at that table rather than restating it. Two copies of this list is how
they drift, and the copy a maintainer follows is the one that has to be right.

## ⚠️ The part worth reading twice

Three items need **more than a secret pasted**, and that is the commonest install failure — silent
every time:

- **The cascade needs three things**: both `DISPATCH_APP_*` secrets, the App *installed on the
  repository*, and its login in `allowed_bots`.
- **Transcript capture needs four**: both AWS secrets, the `AGENT_TRANSCRIPTS` **variable**, and
  the IAM role's OIDC trust policy admitting the repo's `sub` claim.
- **`PROJECTS_TOKEN` cannot be fine-grained** — those cannot reach user-owned Projects v2 at all,
  and the failure reads as an unreachable *project* rather than a bad token.

Also recorded: the stub passes `secrets: inherit` and the workflow declares no `secrets:`
contract, so every repository secret is visible to these jobs — adding one needs no workflow
edit, and the workflow cannot narrow what it receives.

## The table is pinned, in both directions

⚠️ The README table is a **second copy of the workflow's contract**, so it drifts by default. A
new test in `tests/test_workflow.py` derives the real set from `team.yml` and asserts both ways:

- **Undocumented** → a feature nobody knows to switch on. Since every optional secret fails
  *silently*, nothing else would ever surface the omission.
- **Invented** → a maintainer hunting for a secret that does nothing.

Verified by introducing a typo and watching each direction fail, rather than trusting that the
assertions were live. Failure messages were then scoped to name the symbol — the first version
dumped the entire README into the output, which is not a usable diagnosis.

## Verification

`python3 -m unittest discover -s tests` — **78 tests, OK** (up from 73).

Derived facts checked against source, not memory: `secrets.*` and `vars.*` across `team.yml`,
`os.environ` reads across `hooks/`, the `workflow_call` inputs block, the capture action's gate,
and `templates/consumer-stub.yml` for `secrets: inherit`.

## Note

Branched from `mainline` rather than the branch carrying #28, so this stays independent of PR #29
and can merge in either order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_