### PR TITLE
Report why the story PR could not open, and stop calling landed work stranded

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -1726,6 +1726,12 @@ jobs:
           # left it off had that decision overwritten, and #617 closed as completed with its
           # wiring never written.
           HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output || steps.tester.outputs.structured_output || steps.writer.outputs.structured_output }}
+          # ⚠️ What the completion hook already landed, and the only thing separating a run
+          # whose commits are safe on the story branch from one whose commits are stranded. Without
+          # it this hook read "no PR for this branch" as "nothing was landed", announced the run's
+          # own throwaway branch as where the work was safe — a ref that is never pushed and dies
+          # with the runner — and opened a second PR for work that already had one coming.
+          LANDED_REF: ${{ steps.completion.outputs.landed_ref }}
         run: "$RUNNER_TEMP/agent-bin/finish-pr.py"
       - name: Persist the author's handoff
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,27 @@ incident here was caught precisely because something looked wrong. ⚠️ The ca
 when ahead-ness cannot be determined it pushes anyway, because an empty branch is noise and a lost
 capture is the thing the hook exists to prevent.
 
+⚠️ **AND A SUCCESSFUL LANDING SAID IT TOO, WHICH IS WORSE.** `finish-pr.py` finds no PR for the
+run's branch — correct, the story's PR is `open-story-pr.py`'s to open — and then asks whether the
+run produced commits by counting `origin/<default>..HEAD`. `work-completion.py` has already pushed
+those commits onto the story branch and **the runner's branch still carries them**, so that count
+is non-zero on every landing that ever worked. The hook therefore declared landed work stranded,
+pushed the throwaway branch, opened a **second** PR for work that already had one coming, and named
+the runner's branch as where the commits were safe. Measured on run 32561656056: two `::error::`
+lines for one fault, and the louder one was the false one (#44).
+⚠️ **THE DISCRIMINATOR ALREADY EXISTED AND HAD ONE READER.** `work-completion.py` writes
+`landed_ref` to `$GITHUB_OUTPUT`; the workflow read it to set `BASE` for `open-story-pr.py` and
+never gave it to this step, so the hook saw an empty string forever. **This is the sixth dead
+channel here** — after `DEFAULTED`, the author handoff, `decisions` on the PR path,
+`docsCandidates`, and `unrepairable` — and the first where the channel had a reader and simply
+missed a second one, which is why nothing looked wrong. ⚠️ A test now asserts that **every env var
+any hook reads is set somewhere in `team.yml`**: a var read and never set can only ever be empty,
+and that is checkable without knowing which step should set it.
+⚠️ **Counting commits cannot answer this and never could.** A landed commit and a stranded one are
+byte-identical on the runner; the only thing separating them is whether a push happened, which is a
+fact the landing hook holds and the count does not. ⚠️ Any future "did this run produce anything"
+predicate must read the landing's own report, not the graph.
+
 ⚠️ **A rejected landing reconciles by merge**: `work-completion.py` pulls latest, commits the
   merge commit, and pushes. A merge that **conflicts** is not resolved by script — the step fails
   with `unlandable=true`, the commits stay on the run's branch, and resolution is an Implementor
@@ -995,7 +1016,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `work-completion.py` | post, authors | commits the run's changes (message from the handoff's `commitMessage`), lands them on the story's branch — reconciling a rejected push by merge — and closes the task; a **conflicted** merge fails the step with `unlandable=true` |
 | `capture-failure.py` | post, authors — only when a model step failed or the landing conflicted | pushes the run's changes to `failure/<task#>-<run#>-<attempt>` and appends a recovery report on the issue; never fails, never masks the real error |
 | `dispatch-next.py` | post, authors when the landing **closed** the task; **post, Architect** (after the branch exists); **in `delegate`** when an already-shaped story is triggered | reads the story's `### Sequencing` section (derived order without one), and adds `@claude` to every open, unlabelled task in the earliest incomplete wave — the cascade, dark when the App secrets are absent |
-| `finish-pr.py` | post, authors | the net behind `open-story-pr.py` on the as-is path — labels the PR and reconciles the closing keyword with `remaining`. Returns immediately for a task, which has no PR. ⚠️ Also the net under **stranded commits**: a run that committed with nowhere to land gets its branch **pushed** and a PR opened, and **fails the run** if either step cannot happen — pushing first is what makes the recovery real, since `gh pr create --head` needs the branch on the remote and the runner dies moments later (#13) |
+| `finish-pr.py` | post, authors | the net behind `open-story-pr.py` on the as-is path — labels the PR and reconciles the closing keyword with `remaining`. Returns immediately for a task, which has no PR. ⚠️ Also the net under **stranded commits**: a run that committed with nowhere to land gets its branch **pushed** and a PR opened, and **fails the run** if either step cannot happen — pushing first is what makes the recovery real, since `gh pr create --head` needs the branch on the remote and the runner dies moments later (#13). ⚠️ Reads `LANDED_REF` to tell a landing from a loss |
 | `apply-repairs.py` | post, the root role | applies the process repairs it named, records each with what was wrong and why, **reports what it would not fix onto the trigger**, and files an issue rather than repairing the same thing twice |
 | `post-findings.py` | post, Researcher | renders its schema-forced findings onto the spike — the role has no shell, so this is the only way they reach anyone |
 | `post-handoff.py` | post, authors | posts the JSON handoff to the story's issue, and appends its `decisions` to one running log there |
@@ -1081,6 +1102,13 @@ turns and cannot be forgotten.
   ⚠️ The general lesson, since this is the third instance: **a hook that is the sole mechanism for
   something must fail loudly when it cannot do it.** Best-effort is right for bookkeeping that a
   human would notice missing; it is wrong for the only thing that opens a PR.
+  ⚠️ **AND FAILING LOUDLY IS NOT THE SAME AS FAILING USEFULLY.** For as long as it failed, it
+  failed with *"open it by hand"* and no cause (#27) — on a hook where every benign path has
+  already returned, so reaching that line always means a PR genuinely should exist and something
+  refused. Every diagnosis therefore started from zero. It uses `team.gh_raw()` now and prints
+  what `gh` said, plus the two causes that account for most of them — the *Allow GitHub Actions
+  to create and approve pull requests* checkbox, and a job holding `pull-requests: read`. Naming
+  them is not a diagnosis; the reason is. It is what stops the reader re-deriving both each time.
 - ⚠️ **A job that can be triggered on a PR needs `pull-requests: write`, not `issues: write`, to
   say anything at all.** Commenting on a PR goes through the `/issues/{n}/comments` endpoint — so
   the API reads as if `issues` covers it — but the permission GitHub checks is `pull-requests`.
@@ -1222,3 +1250,13 @@ unparented, which is most issues, and `compare` 404s for a deleted branch. `team
 returns `None` on a non-zero exit and `gh_json()` parses only what succeeded, so an error
 body can no longer reach a caller. ⚠️ Do not add a hook that runs `gh` any other way — this
 trap survived being documented and was written again anyway, twice.
+
+⚠️ **`team.gh_raw()` IS THE ONE EXIT, AND IT IS FOR REPORTING, NEVER FOR READING.** Dropping the
+reason is right for a caller that only needs to know whether something worked, and wrong for a
+hook whose whole job is the thing that just failed — `open-story-pr.py` failed the run with no
+cause for as long as it existed (#27). So `gh()` still returns `None` and nothing changes for its
+callers; `gh_raw()` hands back the `CompletedProcess` and is reserved for the message. ⚠️ **Never
+parse its stdout** — that is the trap above, re-opened. ⚠️ **And anything printed from it goes
+through `scrub()` first**: the token rides in the remote URL, `gh` and git both echo that URL in
+errors, and Actions masks the **log** only, so a hook one edit away from posting this to an issue
+is writing outside that protection.

--- a/hooks/finish-pr.py
+++ b/hooks/finish-pr.py
@@ -26,6 +26,7 @@ import team
 
 ROLES = os.environ.get("ROLES") or team.fail("ROLES is required")
 ISSUE = os.environ.get("ISSUE", "")
+LANDED_REF = os.environ.get("LANDED_REF", "")
 HANDOFF = os.environ.get("HANDOFF", "")
 
 if not team.REPO:
@@ -76,6 +77,22 @@ if not pr:
     #
     # So before accepting "nothing to finish", check whether this run actually produced
     # commits. If it did, say so loudly and leave the recovery command on the issue.
+    # ⚠️ A LANDED COMMIT IS NOT STRANDED, and counting `origin/<default>..HEAD` cannot tell the
+    # difference. `work-completion.py` lands the run's work onto the story branch and the
+    # RUNNER's branch still carries it, so the count stays non-zero and this hook announced work
+    # as lost that was already safe — then sent the reader to the staging branch to open a PR
+    # from, when the work was on the story branch (#44). Measured on run 32561656056: two
+    # `::error::` lines for one fault, and the louder one was the false one.
+    #
+    # ⚠️ `landed_ref` already existed as a `work-completion.py` output; it was simply never given
+    # to this step. The signal was produced and had one reader.
+    if LANDED_REF:
+        print(
+            f"this run's work landed on `{LANDED_REF}` — not stranded. Its PR belongs to "
+            "open-story-pr.py, which reports its own failure."
+        )
+        raise SystemExit(0)
+
     stranded = ""
     default = (
         team.gh_json("repo", "view", team.REPO, "--json", "defaultBranchRef") or {}

--- a/hooks/open-story-pr.py
+++ b/hooks/open-story-pr.py
@@ -94,10 +94,11 @@ if tasks:
     # ⚠️ Kept explicit because the correct rule with a stale reason attached is exactly what gets
     # "simplified" away by someone who notices only that the reason is wrong.
 
-if team.gh(
+created = team.gh_raw(
     "pr", "create", "--repo", team.REPO, "--base", default, "--head", BASE,
     "--title", title, "--body", "\n".join(lines) + "\n",
-) is not None:
+)
+if created.returncode == 0:
     print(f"opened the story PR for {BASE}")
 else:
     # ⚠️ FAILS THE STEP, and that is the whole lesson of this hook's history. It warned instead,
@@ -109,4 +110,19 @@ else:
     # ⚠️ Reaching this line means a PR genuinely should exist: every benign case — merged into the
     # default branch, an unresolvable story, a PR already open, a branch not ahead — returned
     # earlier. So there is no legitimate reason to be here and quiet.
-    team.fail(f"could not open the story PR for {BASE} — open it by hand.")
+    # ⚠️ SAY WHY. It failed with no cause for as long as it existed (#27), so every diagnosis
+    # started from zero on a hook whose benign paths have all already returned. `gh` writes its
+    # refusal to stdout as often as stderr, so both are read; `scrub()` because the token rides
+    # in the remote URL and Actions masks the log, not an issue comment.
+    #
+    # ⚠️ The two known causes are named because neither is guessable from `gh`'s own wording:
+    # the repository setting is a checkbox nobody remembers, and the permission is a one-line
+    # workflow edit. Naming them is not a diagnosis — the reason above is — it is what stops the
+    # reader re-deriving both every time.
+    reason = team.scrub((created.stderr or created.stdout).strip()) or "no reason reported"
+    team.fail(
+        f"could not open the story PR for {BASE} — open it by hand. gh said: {reason} "
+        "Two causes account for most of these: 'Allow GitHub Actions to create and approve "
+        "pull requests' is off in Settings -> Actions -> General, or the job lacks "
+        "`pull-requests: write`."
+    )

--- a/hooks/team.py
+++ b/hooks/team.py
@@ -88,6 +88,22 @@ def warn(message: str) -> None:
     print(f"::warning::{message}")
 
 
+def gh_raw(*args: str) -> subprocess.CompletedProcess:
+    """`gh`, with the failure preserved — for the few callers that must REPORT why.
+
+    ⚠️ `gh()` drops the reason on the floor, deliberately: a caller that only needs to know
+    whether something worked must not be handed an error body it might mistake for data. But a
+    hook whose whole job is the thing that just failed has to say what went wrong, and #27 is
+    what that costs — `open-story-pr.py` failed the run with "open it by hand" and no cause, on
+    a create that genuinely should have succeeded.
+
+    ⚠️ ANYTHING PRINTED FROM THIS MUST GO THROUGH `scrub()`. The token is in the remote URL, git
+    and gh both echo that URL in errors, and Actions masks secrets in the LOG only — a hook
+    posting this into an issue comment is writing outside that protection.
+    """
+    return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+
+
 def gh(*args: str, check: bool = False) -> str | None:
     """Run a `gh` command and return stdout, or None if it failed.
 
@@ -95,10 +111,10 @@ def gh(*args: str, check: bool = False) -> str | None:
     successful response to anything that only checks for output. Callers used to capture
     that JSON blob and treat it as a value. Here a non-zero exit returns None, full stop,
     and there is no way for an error body to be mistaken for data.
+
+    Need the reason rather than the value? Use `gh_raw()`.
     """
-    result = subprocess.run(
-        ["gh", *args], capture_output=True, text=True, check=False
-    )
+    result = gh_raw(*args)
     if result.returncode != 0:
         if check:
             fail(f"gh {' '.join(args)} failed: {result.stderr.strip()}")

--- a/tests/stub_team.py
+++ b/tests/stub_team.py
@@ -76,6 +76,20 @@ def is_epic(number):
     return kind(number) == "epic"
 
 
+class _Result:
+    def __init__(self, rc, out, err):
+        self.returncode, self.stdout, self.stderr = rc, out, err
+
+
+def gh_raw(*args):
+    _record("gh_raw", args)
+    joined = " ".join(map(str, args))
+    for needle in json.loads(os.environ.get("STUB_GH_FAIL", "[]")):
+        if needle in joined:
+            return _Result(1, "", os.environ.get("STUB_GH_STDERR", "GraphQL: refused"))
+    return _Result(0, "", "")
+
+
 def gh(*args, check=False):
     _record("gh", args)
     joined = " ".join(map(str, args))

--- a/tests/test_finish_pr.py
+++ b/tests/test_finish_pr.py
@@ -48,5 +48,77 @@ class StrandedCommits(HookCase):
         self.assertNotIn("1276-cleanup-getting-started", fx.origin_git("branch").stdout)
 
 
+class LandedWorkIsNotStranded(HookCase):
+    """#44: `work-completion.py` lands the run's work on the story branch and the RUNNER's
+    branch still carries the same commits, so `origin/<default>..HEAD` stays non-zero. This
+    hook read that as stranded work — pushed the throwaway branch, opened a second PR for
+    work that already had one coming, and told the reader their commits were safe on a ref
+    that dies with the runner. Measured on run 32561656056: two `::error::` lines for one
+    fault, and the louder one was the false one.
+
+    `landed_ref` was already a `work-completion.py` output; the step was simply never given it."""
+
+    STORY = {"43": {"body": "Branch: `43-give-story-and-task-colours`",
+                    "title": "Give story and task their own colours"}}
+
+    def finish(self, fx, **env):
+        return self.run_hook("finish-pr.py", {
+            "ISSUE": "43", "GH_TOKEN": "ghs_fixturetoken", "ROLES": "implementor",
+            "STUB_ISSUES": self.STORY, "STUB_PRS": [], "STUB_LISTING": [],
+            **env,
+        }, cwd=fx.wc)
+
+    def landed_run(self):
+        """An as-is story: the run's own branch carries commits that are already on the
+        story branch. Without LANDED_REF this is indistinguishable from stranded work."""
+        fx = GitFixture(self._tmp)
+        fx.checkout_new("claude/issue-43-20260822")
+        fx.commit("labels.json", "recolour story and task")
+        return fx
+
+    def test_it_exits_quietly_and_names_where_the_work_actually_is(self):
+        fx = self.landed_run()
+
+        r = self.finish(fx, LANDED_REF="43-give-story-and-task-colours")
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("43-give-story-and-task-colours", r.stdout)
+        self.assertIn("not stranded", r.stdout)
+
+    def test_it_does_not_push_the_runners_throwaway_branch(self):
+        fx = self.landed_run()
+
+        self.finish(fx, LANDED_REF="43-give-story-and-task-colours")
+
+        self.assertNotIn("claude/issue-43", fx.origin_git("branch").stdout)
+
+    def test_it_opens_no_second_pr(self):
+        """open-story-pr.py owns the story's PR. A second one here splits the only review
+        surface anyone reads, which is the thing one-PR-per-story exists to prevent."""
+        fx = self.landed_run()
+
+        r = self.finish(fx, LANDED_REF="43-give-story-and-task-colours")
+
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    def test_it_never_calls_the_runners_branch_the_safe_one(self):
+        """⚠️ The most dangerous thing this system can write is a message telling someone not
+        to look further. `claude/issue-43-...` is never pushed and dies with the container."""
+        fx = self.landed_run()
+
+        r = self.finish(fx, LANDED_REF="43-give-story-and-task-colours")
+
+        self.assertNotIn("claude/issue-43", r.stdout + r.stderr)
+
+    def test_without_the_ref_the_stranded_recovery_still_fires(self):
+        """The net under a genuinely stranded run is unchanged — LANDED_REF only ever
+        distinguishes a landing from a loss, it does not switch the recovery off."""
+        fx = self.landed_run()
+
+        self.finish(fx)
+
+        self.assertIn("claude/issue-43", fx.origin_git("branch").stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_open_story_pr.py
+++ b/tests/test_open_story_pr.py
@@ -1,0 +1,87 @@
+import unittest
+from harness import HookCase
+
+# One story, one task, the task closed — the state in which the hook is supposed to act.
+READY = {
+    "43": {
+        "title": "Give story and task their own colours",
+        "kids": [{"number": 45, "title": "Recolour the labels", "state": "closed"}],
+    }
+}
+
+
+class ReportsWhyItCouldNotOpen(HookCase):
+    """#27: the hook failed the run with 'open it by hand' and no cause. Every benign path
+    returns earlier, so reaching the create and not creating anything is always a real fault —
+    and the reader had nothing to act on."""
+
+    def open_pr(self, **env):
+        return self.run_hook("open-story-pr.py", {
+            # ⚠️ A realistic token, not "t". `scrub()` is a plain replace, so a
+            # one-character token rewrites every matching letter in gh's message and the
+            # assertions below fail on the test's own fixture rather than the hook.
+            "BASE": "43-give-story-and-task-colours", "GH_TOKEN": "ghs_fixturetoken",
+            "STUB_ISSUES": READY, "STUB_PRS": [], "STUB_AHEAD": "1",
+            **env,
+        })
+
+    def test_the_reason_gh_gave_reaches_the_log(self):
+        r = self.open_pr(
+            STUB_GH_FAIL=["pr create"],
+            STUB_GH_STDERR="GraphQL: GitHub Actions is not permitted to create pull requests",
+        )
+
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("::error::", r.stdout + r.stderr)
+        self.assertIn("not permitted to create pull requests", r.stdout + r.stderr)
+
+    def test_it_names_the_two_causes_worth_checking(self):
+        r = self.open_pr(STUB_GH_FAIL=["pr create"])
+
+        self.assertIn("Settings -> Actions -> General", r.stdout + r.stderr)
+        self.assertIn("pull-requests: write", r.stdout + r.stderr)
+
+    def test_a_silent_failure_still_says_something_rather_than_nothing(self):
+        r = self.open_pr(STUB_GH_FAIL=["pr create"], STUB_GH_STDERR="")
+
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("no reason reported", r.stdout + r.stderr)
+
+    def test_the_token_never_reaches_the_report(self):
+        """⚠️ `gh` echoes the remote URL in its errors and the token rides in it. Actions masks
+        the LOG only, and this text is one edit away from being posted on an issue."""
+        r = self.open_pr(
+            GH_TOKEN="ghs_supersecret",
+            STUB_GH_FAIL=["pr create"],
+            STUB_GH_STDERR="fatal: https://x-access-token:ghs_supersecret@github.com/o/r denied",
+        )
+
+        self.assertNotIn("ghs_supersecret", r.stdout + r.stderr)
+        self.assertIn("***", r.stdout + r.stderr)
+
+    def test_the_success_path_is_unchanged(self):
+        r = self.open_pr()
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("opened the story PR", r.stdout)
+        self.assertTrue(self.calls_matching(r, "pr", "create"))
+
+    def test_a_branch_that_is_not_ahead_returns_before_the_create(self):
+        """The benign paths must keep returning quietly — the failure above is loud precisely
+        because nothing legitimate reaches it."""
+        r = self.open_pr(STUB_AHEAD="0")
+
+        self.assertEqual(r.returncode, 0)
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    def test_an_open_task_holds_the_pr_back(self):
+        waiting = {"43": {"title": "Colours", "kids": [{"number": 45, "state": "open"}]}}
+        r = self.open_pr(STUB_ISSUES=waiting)
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("still open", r.stdout)
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 import unittest
 
 TEAM = (pathlib.Path(__file__).resolve().parent.parent / ".github/workflows/team.yml").read_text()
@@ -63,6 +64,46 @@ class TeamWorkflow(unittest.TestCase):
                     break
                 self.assertFalse(nxt.strip().startswith("#"),
                                  f"comment inside if block at line {j+1}")
+
+
+class NoHookReadsAChannelNobodyFills(unittest.TestCase):
+    """⚠️ THE DEAD CHANNEL IS THIS PACKAGE'S MOST-REPEATED DEFECT — `DEFAULTED`, the author
+    handoff, `decisions` on the PR path, `docsCandidates`, `unrepairable`, and #44: a signal
+    produced, consumed by nobody, and believed to work because nothing fails when it is absent.
+
+    `finish-pr.py` is the sixth. `work-completion.py` had emitted `landed_ref` for as long as it
+    had existed and the workflow read it at ONE of its two readers, so the hook that needed it to
+    tell a landing from a loss saw an empty string forever — announced landed work as stranded,
+    pushed the runner's throwaway branch, and named a ref that dies with the container as where
+    the commits were safe.
+
+    ⚠️ This asserts the WIRING, not the value: a var read by a hook and set nowhere in the
+    workflow can only ever be empty. It cannot check that the right STEP sets it — several hooks
+    take different vars per mode, and demanding all of them at every site would be false — so a
+    per-hook test still has to cover which site."""
+
+    HOOKS = pathlib.Path(__file__).resolve().parent.parent / "hooks"
+    # Actions sets these itself, and the test harness sets the last two.
+    AMBIENT = {"GITHUB_OUTPUT", "RUNNER_TEMP", "GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT",
+               "GITHUB_SERVER_URL", "GITHUB_REPOSITORY", "HOOKS_DIR", "CALLS_FILE"}
+
+    def test_every_env_var_a_hook_reads_is_set_somewhere(self):
+        for hook in sorted(self.HOOKS.glob("*.py")):
+            src = hook.read_text()
+            reads = set(re.findall(
+                r"os\.environ(?:\.get)?[\(\[]\s*\"([A-Z][A-Z0-9_]*)\"", src))
+            for name in sorted(reads - self.AMBIENT):
+                with self.subTest(hook=hook.name, var=name):
+                    # `NAME:` in an env block, or `NAME=` inline on a run line.
+                    self.assertRegex(
+                        TEAM, rf"(^|[\s;]){name}[:=]",
+                        f"{hook.name} reads {name}; team.yml never sets it, so it is always empty",
+                    )
+
+    def test_finish_pr_is_told_what_the_landing_landed(self):
+        """The specific wiring #44 was missing — the hook cannot distinguish a landed run from
+        a stranded one without it, and both look identical from `origin/<default>..HEAD`."""
+        self.assertIn("LANDED_REF: ${{ steps.completion.outputs.landed_ref }}", TEAM)
 
 
 class ReadmeDocumentsEveryInput(unittest.TestCase):


### PR DESCRIPTION
Two defects observed on the same run (32561656056), both in the pair of hooks that run after a landing. The run reported two `::error::` lines for one fault, and the louder one was the false one.

## #27 — the story PR failed with no cause

`open-story-pr.py` failed the run with *"open it by hand"* and nothing else. Every benign path in that hook returns earlier — merged into the default branch, an unresolvable story, a PR already open, tasks still open, a branch not ahead — so reaching the `pr create` and not creating anything **always** means something refused. The reader was given nothing to act on, and every diagnosis started from zero.

- **`team.gh_raw()`** is a new, deliberately narrow exit from `gh()`'s reason-dropping. `gh()` returns `None` on failure so an error body can never be mistaken for data; that stays. `gh_raw()` hands back the `CompletedProcess` and is reserved for callers whose whole job is the thing that just failed.
- Its output goes through **`scrub()`** — the token rides in the remote URL, `gh` echoes that URL in errors, and Actions masks the **log** only.
- The failure now names what `gh` said, plus the two causes that account for most of them: the *Allow GitHub Actions to create and approve pull requests* checkbox, and a job holding `pull-requests: read`. Naming them is not the diagnosis — the reason is — it is what stops the reader re-deriving both every time.

## #44 — a landed run was announced as stranded

`finish-pr.py` finds no PR for the run's branch (correct — the story's PR belongs to `open-story-pr.py`) and then asks whether the run produced commits by counting `origin/<default>..HEAD`. `work-completion.py` has already pushed those commits onto the story branch and **the runner's branch still carries them**, so that count is non-zero on every landing that ever worked.

So the hook:
- pushed the runner's throwaway branch,
- opened a **second** PR for work that already had one coming, splitting the only review surface anyone reads,
- and told the reader the commits were safe on a ref that is never kept and dies with the container.

**The discriminator already existed and had one reader.** `work-completion.py` writes `landed_ref` to `$GITHUB_OUTPUT`; the workflow read it to set `BASE` for `open-story-pr.py` and never gave it to the `finish-pr` step, so the hook saw an empty string forever.

That is the **sixth dead channel** in this package — after `DEFAULTED`, the author handoff, `decisions` on the PR path, `docsCandidates`, and `unrepairable` — and the first where the channel had a reader and simply missed a second one, which is why nothing looked wrong.

Counting commits could never have answered this: a landed commit and a stranded one are byte-identical on the runner. The only thing separating them is whether a push happened, which is a fact the landing hook holds and the graph does not.

## Tests

- `tests/test_open_story_pr.py` (new, 7 cases) — the reason reaches the log, the two causes are named, a silent failure still says something, the token never reaches the report, and every benign path keeps returning quietly.
- `tests/test_finish_pr.py` (+5 cases) — with `LANDED_REF` the hook exits quietly, does not push the throwaway branch, opens no second PR, and never names the runner's branch as safe; without it the genuine stranded-commit recovery still fires.
- `tests/test_workflow.py` (+2 cases) — **every env var any hook reads is set somewhere in `team.yml`**. A var read and never set can only ever be empty, and that is checkable without knowing which step ought to set it. Verified this general check flags the missing `LANDED_REF` against the pre-fix workflow.

Both fixes were reproduced against the old code before being written: the four new `finish-pr` cases fail on `mainline` with output showing exactly the production symptom (the throwaway branch pushed, a second PR created), and four of the seven `open-story-pr` cases fail with the bare *"open it by hand"*.

Gate: `python3 -m unittest discover -s tests` — **114 passed**.

Closes #27
Closes #44

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_