### PR TITLE
Recolour story, task and spike off the routing labels

### DIFF
--- a/templates/labels.json
+++ b/templates/labels.json
@@ -51,7 +51,7 @@
   },
   {
     "name": "spike",
-    "color": "1d76db",
+    "color": "e5399f",
     "description": "A question the work cannot start without \u2014 answered by the Researcher, ships nothing"
   },
   {
@@ -61,12 +61,12 @@
   },
   {
     "name": "story",
-    "color": "0e8a16",
+    "color": "12796b",
     "description": "One shippable outcome, carrying its own branch and the PR that closes it"
   },
   {
     "name": "task",
-    "color": "1d76db",
+    "color": "8bc34a",
     "description": "A slice of a story \u2014 its commits land on the story's branch, and the story owns the PR"
   }
 ]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -213,6 +213,41 @@ class CanonicalLabels(unittest.TestCase):
                     len(l["description"]), 100,
                     f"{l['name']} is {len(l['description'])} chars; gh will reject it")
 
+    def test_no_two_labels_share_a_colour_unless_the_pairing_is_deliberate(self):
+        """⚠️ THE COLOUR IS THE ONLY THING A BOARD SHOWS AT A GLANCE, and this set carries two
+        kinds of label for two different readers: ROUTING says what should happen to an issue and
+        is the maintainer's, CLASSIFICATION says what an issue is and anyone filing may apply it.
+        `story` shipped in the tester's green and `task`/`spike` in the authors' blue, so the
+        board erased that line exactly where CLAUDE.md draws it in prose.
+
+        Three pairings are deliberate — shaping, authoring, done — and they are enumerated here
+        rather than derived, so a fourth is an edit someone has to argue for. The assertion runs
+        both ways: nothing else may collide, and these three may not be silently split.
+
+        ⚠️ Pinned as the GENERAL rule rather than as the three collisions that were found. The
+        next colour edit will be somewhere else in the set, and a test naming only today's
+        offenders would pass through the same mistake made one label over."""
+        deliberate = {
+            frozenset({"@claude/architect", "@claude/researcher"}),
+            frozenset({"@claude/implementor", "@claude/designer"}),
+            frozenset({"@claude/tester", "@claude/complete"}),
+        }
+        groups = {}
+        for l in self.labels:
+            groups.setdefault(l["color"], set()).add(l["name"])
+        for color, names in sorted(groups.items()):
+            with self.subTest(color=color):
+                if len(names) > 1:
+                    self.assertIn(
+                        frozenset(names), deliberate,
+                        f"{sorted(names)} all share #{color}; only the role pairings may")
+        by_name = {l["name"]: l["color"] for l in self.labels}
+        for pair in deliberate:
+            a, b = sorted(pair)
+            with self.subTest(pairing=(a, b)):
+                self.assertEqual(by_name[a], by_name[b],
+                                 f"{a} and {b} are a deliberate pairing and must stay one colour")
+
     def test_the_task_description_does_not_claim_a_task_owns_a_pr(self):
         """⚠️ IT SHIPPED SAYING THE OPPOSITE OF THE HIERARCHY: "A slice of a story, with its own
         branch and PR" — a fossil of the version before task PRs were removed.


### PR DESCRIPTION
Story PR for `43-give-story-and-task-colours`.

**Worked as-is** — this story was small enough for one author, and this PR is its whole delivery.

Closes #43

## What changed

Colours only. No `name`, no `description`, nothing else in the set.

| label | was | now | why that hue |
|---|---|---|---|
| `story` | `0e8a16` (tester/complete green) | `12796b` teal | ~172°, the empty slot between green (124°) and blue (209°), and dark where blue is bright |
| `task` | `1d76db` (implementor/designer blue) | `8bc34a` yellow-green | ~88°, light, against `0e8a16`'s dark 124° and `fbca04`'s 48° |
| `spike` | `1d76db` (implementor/designer blue) | `e5399f` pink | ~324°, sitting ~32° from both `be14e5` epic (292°) and `d73a4a` bug (356°) |

Routing labels say what should *happen* to an issue and belong to the maintainer; classification
labels say what an issue *is* and anyone filing may apply one. Sharing a colour across that line
undid on the board the distinction the docs make in prose.

## The test

`CanonicalLabels.test_no_two_labels_share_a_colour_unless_the_pairing_is_deliberate` pins the
**general** rule, in both directions:

- group by colour; a group of more than one must be *exactly* one of the three deliberate pairings
  (`architect`+`researcher`, `implementor`+`designer`, `tester`+`complete`)
- each deliberate pairing must still share a colour, so nobody silently splits one either

Written as the general rule rather than as the three collisions found — a test naming today's
offenders would pass through the same mistake made one label over.

## One deviation from the issue's implementation notes

`spike` is `e5399f`, not the suggested `d6336c`. `d6336c` is hue ~339°, only ~17° from `bug`'s
`d73a4a` at comparable saturation and lightness — and `spike` and `bug` are both classification
labels, so they are the pair most likely to sit adjacent in a board's label column, which is the
exact adjacency this story exists to disambiguate. The notes stated the requirement as
distinctness, not those hexes.

Recorded in the decisions log on #43, along with the general finding: classification labels now
occupy the three hue slots the routing set leaves empty (teal ~172°, yellow-green ~88°, pink
~324°), so a future colour edit picks from what remains of those gaps rather than guessing fresh.

## Verification

`python3 -m compileall -q hooks && python3 -m unittest discover -s tests` — **101 passed** on this
branch's head.

⚠️ The authoring run could **not** run that gate itself: the Implementor's allowlist grants
`npm|npx|node` and no `python3`, so it verified the assertion's logic with `node` against the real
JSON and said plainly that this was not the Python suite. That gap is filed as #46. The suite above
was run separately.

## Provenance, and why this PR was opened by hand

The work was produced by the Implementor on run
[32561656056](https://github.com/matt-whitaker/claude-team/actions/runs/32561656056) and landed
correctly on this branch. `open-story-pr.py` then failed with "open it by hand" and no cause (#27),
and `finish-pr.py` announced the landed commits as stranded (#44). Both are fixed in #45; this PR
is the one that fell through the gap before that landed.

## Follow-ups, already out of scope

- **#38** — re-run the local `gh` label loop against this repo, *after* this merges, or the change
  reaches nothing.
- **#39** — consumer boards that already applied the old colours.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_