### PR TITLE
Name the as-is story in the Architect prompt, and scope the Writer rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,20 @@ test is scripted, not judged: a task's `Branch:` line names its *story's* branch
 `story_from_branch(named) != ISSUE`; when they are **equal**, the executing issue owns that branch
 and its work is the whole story. There is no parent for it to merge into.
 
+⚠️ **AND THE ARCHITECT MUST BE TOLD IT MAY PRODUCE ONE, WHICH FOR A LONG TIME IT WAS NOT.**
+`prompts/_shared.md` described the as-is story from the **author's** side — *"You are a STORY
+worked as-is"* — which tells a role what it *is*, never that shaping may end there.
+`prompts/architect.md` was silent on it, so the prompt described two of the three shapes
+`delegate.py` routes: a story with tasks dispatches its first wave, one with no tasks falls
+through to its stamped author, and one with neither stamp nor tasks defaults to the Implementor
+and announces the guess on the issue at **every** trigger.
+⚠️ **It worked anyway once, and that is what hid it.** The Architect on #43 reached the right
+shape by citing **CLAUDE.md** — this repo's own file, which in a consumer belongs to the consumer
+and says nothing of the sort. Behaviour that depends on the package being its own consumer is not
+portable, and the drill only passed because the answer happened to be lying around.
+⚠️ **The stamp is the expensive half.** A Branch line with no Role line is the one shape that
+costs a run before any work starts, and it recurs on every trigger rather than once.
+
 ⚠️ **Retargeting one of those onto its own story branch is the failure**, and it looks like
 correctness. The work lands on a branch nobody has merged, `close-merged-work.py` closes the story
 on that merge anyway, and finishing it then needs a second PR for an issue that is already closed —
@@ -803,11 +817,25 @@ a document is deriving from the implementation at one remove, with the rule agai
 satisfied. Ordering the Writer ahead of the authors makes "from intent, not from the diff" true
 by construction rather than by instruction, and hands the authors a sharper brief besides.
 
-⚠️ **Its task is cut on EVERY story, unconditionally; the Tester's is judged.** Every story
-changes what the product does, so there is always something to specify. Before the spec existed
-the argument was weaker — the Architect could not predict `docsCandidates`, and asked to guess
-it answered "no" every time: across every story before that rule, not one Writer task was ever
-cut.
+⚠️ **Its task is cut on every story THAT DIVIDES, and inside that scope it is unconditional;
+the Tester's is judged.** Every story changes what the product does, so there is always something
+to specify. Before the spec existed the argument was weaker — the Architect could not predict
+`docsCandidates`, and asked to guess it answered "no" every time: across every story before that
+rule, not one Writer task was ever cut.
+
+⚠️ **THE UNSCOPED WORDING CONTRADICTED THE DON'T-SPLIT RULE, AND BOTH WERE ABSOLUTE.** *"A story
+one author can finish should not be split"* against *"a `Role: writer` task on EVERY story,
+Always — not a judgement call"*: a Writer task **is** a task, so obeying the second made the
+first unreachable, with no precedence stated anywhere. A run had to disobey one silently, and
+did (#47).
+⚠️ **The scope is the fix; softening the rule is not.** *"Cut one where it seems needed"* reverts
+to precisely the failure that produced the rule. What changed is **which decision the Architect
+is making**: the size question in step 4, which it was making anyway — not "does this deserve a
+spec", which it has answered wrong every time it was asked.
+⚠️ **The discriminator is stated rather than left to feel:** *does a specification need writing
+before the code?* If yes, the story divides and the Writer task is cut first. Ambiguity resolves
+to **divide** — an unnecessary Writer run is one cheap run reporting nothing to specify, and a
+skipped necessary one is a story shipping with nothing saying what the product now promises.
 
 ⚠️ **Running first strands `docsCandidates`, and that must be handled rather than left.** The
 authors emit them after the Writer has finished, so nothing consumes them in the same story — a

--- a/prompts/architect.md
+++ b/prompts/architect.md
@@ -117,8 +117,34 @@ work:
    cannot resolve the story, and every role that follows has nowhere to commit.
    ⚠️ An existing branch is left untouched by the hook, commits or not — so if a story is
    re-shaped, its branch keeps whatever an author already put there.
-4. **Cut the story into tasks** if it needs dividing. A story one author can finish should
-   not be split — extra issues cost more than they save.
+4. **Decide whether the story divides, and put that decision in its shape.** There are exactly
+   two outcomes and both are normal — the shape is how every hook downstream tells them apart:
+
+   - **It divides** → cut tasks. Each carries the two lines in *Every task you create*, and a
+     `Role: writer` task comes first (see the next section).
+   - **It does not** → leave it whole and stamp the **story itself**, on its own line beside
+     its Branch line:
+     ```
+     **Role: <implementor|designer|tester|writer>**
+     ```
+
+   ⚠️ **The second one is the AS-IS STORY, and it is a real deliverable rather than a
+   shortcut.** Its `Branch:` line names *its own* issue number, so nothing sits between it and
+   the default branch: the stamped author works the story directly, a hook lands the work on
+   that branch and opens its PR against the default branch, and the issue closes when that PR
+   merges. It has no tasks, so nothing dispatches and nothing waits.
+
+   ⚠️ **A story one author can finish should not be split** — extra issues cost more than
+   they save, and a Writer task plus an author task for a one-file change is the cost this is
+   guarding against.
+
+   ⚠️ **THE STAMP IS NOT OPTIONAL ON AN AS-IS STORY, and leaving it off is the expensive
+   mistake here.** Routing reads that line to pick the role. Without it there is nothing to
+   read: the router falls back to the Implementor, announces that it guessed, and posts *"you
+   probably meant to trigger one of its tasks"* on the issue — on **every** trigger, not once.
+   A story with a Branch line and no Role line is the one shape that costs a run before any
+   work starts.
+
    ⚠️ **Read the existing sub-issues before creating any.** A story you are re-triggered on
    may already be decomposed. Verify what is there — do the tasks still describe the code
    accurately, do they carry both required lines — and correct or add rather than duplicate.
@@ -131,7 +157,8 @@ work:
 No role chains off another. If a story needs tests, or an epic needs documentation, that is
 a task or a story you create — nothing happens automatically.
 
-- **A `Role: writer` task on EVERY story, created FIRST. Always — not a judgement call.**
+- **A `Role: writer` task on every story you cut into tasks, created FIRST — not a judgement
+  call once the story divides at all.**
   ⚠️ The Writer owns the product specification, and a specification is only worth anything if
   it says what the code *should* do — which it cannot if it was written by reading the code
   that already exists. Ordering it ahead of the authors is what makes that true by
@@ -139,6 +166,18 @@ a task or a story you create — nothing happens automatically.
   Every story changes what the product does, so there is always something to specify; a Writer
   run that concludes otherwise is a correct, cheap, visible outcome, and a story that silently
   never gets one is not.
+  ⚠️ **DO NOT REOPEN THIS AS A JUDGEMENT ABOUT WHETHER DOCUMENTATION IS NEEDED.** That question
+  was asked once, and across every story shaped before this rule existed the answer was "no"
+  every single time — not one Writer task was ever cut. The decision you are making is the
+  **size** one in step 4, which you were making anyway; it is not "does this deserve a spec".
+  ⚠️ **An as-is story has no tasks, so it has no Writer task**, and that is the shape working
+  rather than the rule being skipped: one author does the whole thing. The discriminator is not
+  how small the change feels — it is **whether a specification needs writing before the code**.
+  If it does, the story divides: cut the Writer task first and stop treating it as as-is.
+  ⚠️ **In doubt, divide.** The cost of an unnecessary Writer task is one cheap run that reports
+  it found nothing to specify. The cost of skipping a needed one is a story that ships with
+  nothing saying what the product now promises, discovered when the next Tester has nothing to
+  derive from.
 - **A `Role: tester` task per story that needs one**, ordered **last**. Tests belong next to
   the work while it is fresh, and the Tester reads both the specification the Writer wrote and
   the authors' handoff comments on the story's **issue** — so triggering it before they have
@@ -157,6 +196,12 @@ where to commit. Without it they cannot work at all.
 ⚠️ **The Branch line always names the STORY's branch**, on every task. It is what the author
 bases its own branch on and merges back into — never a branch for the task itself. You cut
 one branch per story and no more; the authors cut their own.
+
+⚠️ **AN AS-IS STORY CARRIES THE SAME TWO LINES, and the difference is which issue the branch
+names.** On a task the Branch line names a *different* issue's branch, so the number it starts
+with is not its own; on an as-is story it names its **own** number. That is not a convention
+anyone has to remember — it is the exact test every hook and the router already run to tell a
+task from a story worked directly, so writing the lines correctly is the whole of it.
 
 ⚠️ **The role stamp is load-bearing.** Routing is a shell script that reads this line — it
 does not judge which role should pick a task up. You answer that once, here, with the code

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -117,9 +117,6 @@ class ArchitectPromptExamplesParse(unittest.TestCase):
         self.assertIn("NEVER AS PROSE", self.prompt)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 class RepairSchemaMatchesTheHook(unittest.TestCase):
     """The schema is what the model reads; the hook is what enforces. They must agree."""
 
@@ -131,3 +128,58 @@ class RepairSchemaMatchesTheHook(unittest.TestCase):
         schema = json.dumps(json.load(open(root / "schemas/repairs.json")))
         missing = [label for label in allowed if label not in schema]
         self.assertEqual(missing, [], f"the hook accepts {missing} but the schema never mentions them")
+
+
+class TheArchitectPromptNamesTheAsIsStory(unittest.TestCase):
+    """⚠️ #47: THE PROMPT DESCRIBED TWO OF THE THREE SHAPES A STORY CAN END IN.
+
+    `delegate.py` routes three ways — a story WITH tasks dispatches its first wave, a story with
+    no tasks falls through to its stamped author (the as-is path), and one with neither stamp nor
+    tasks defaults to the Implementor and announces the guess. The prompt described the first,
+    was silent on the second, and carried two absolute rules that could not both hold on a small
+    story: *don't split what one author can finish* against *a Writer task on EVERY story,
+    always*. A Writer task is a task, so obeying the second made the first unreachable.
+
+    The Architect got it right on #43 anyway — by citing **CLAUDE.md**, which is this repo's own
+    file and says nothing of the sort in a consumer. Prose review passed the contradiction, so it
+    is pinned here instead."""
+
+    def setUp(self):
+        root = pathlib.Path(__file__).resolve().parent.parent
+        self.prompt = (root / "prompts/architect.md").read_text()
+
+    def test_the_as_is_story_is_named_as_an_outcome(self):
+        self.assertIn("AS-IS STORY", self.prompt)
+
+    def test_the_story_level_role_stamp_is_shown(self):
+        """The stamp is what routing reads. Without it the router guesses and says so on the
+        issue at every trigger — so the prompt has to show the line, not just mention it."""
+        self.assertRegex(
+            self.prompt,
+            r"\*\*Role: <implementor\|designer\|tester\|writer>\*\*",
+            "the as-is story's Role line is not shown as a literal the Architect can copy")
+
+    def test_the_writer_rule_is_scoped_rather_than_unconditional(self):
+        """⚠️ BOTH DIRECTIONS MATTER. Unscoped, it contradicts 'do not split a one-author
+        story'. Softened to a judgement, it reverts to the failure that produced it — asked to
+        predict whether documentation was needed, the Architect answered no on every story ever
+        shaped. So: scoped to stories that divide, and still not a judgement inside that scope."""
+        self.assertNotIn("task on EVERY story", self.prompt)
+        self.assertIn("every story you cut into tasks", self.prompt)
+        self.assertRegex(
+            self.prompt, r"not a judgement\s+call once the story divides",
+            "the Writer rule is unscoped again — it contradicts step 4 that way")
+
+    def test_the_reason_the_rule_exists_survives_the_rescoping(self):
+        """A rule with its history removed is the one a later edit softens away."""
+        self.assertIn("not one Writer task was ever cut", self.prompt)
+
+    def test_the_discriminator_is_stated_rather_than_left_to_feel(self):
+        self.assertIn("whether a specification needs writing before the code", self.prompt)
+
+    def test_ambiguity_resolves_towards_dividing(self):
+        self.assertIn("In doubt, divide", self.prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Story PR for `47-name-the-as-is-story`.

**Worked as-is** — a wording fix in one prompt plus its tests, small enough for one author.

Closes #47

## The contradiction

Two absolute rules that could not both hold on a small story:

| line | rule |
|---|---|
| `architect.md:120` | *"A story one author can finish should not be split — extra issues cost more than they save."* |
| `architect.md:134` | *"A `Role: writer` task on **EVERY** story, created FIRST. Always — not a judgement call."* |

A Writer task **is** a task, so obeying the second made the first unreachable — with no
precedence stated anywhere. A run had to disobey one silently, and did.

## The missing shape

`delegate.py` routes three ways for a shaped story. The prompt described two.

| shape | routing | prompt |
|---|---|---|
| story **with** tasks | `delegate.py:309` — dispatches wave 1, no role runs | described |
| story **as-is** — no tasks, own `Branch:`, `Role:` stamp | falls through to the stamped author | **silent** |
| no tasks, **no stamp** | defaults to Implementor, sets `DEFAULTED`, posts a remedy comment | — |

`_shared.md:239` describes the as-is story from the **author's** side — *"You are a STORY worked
as-is"*. That tells a role what it *is*, never that shaping may end there. `architect.md` had
nothing; `Role:` appeared only inside *"Every task you create carries two lines"*.

⚠️ **It worked anyway once, and that is what hid it.** The Architect on #43 reached the right
shape by citing **CLAUDE.md** — this repo's own file, which in a consumer belongs to the consumer
and says nothing of the sort. Behaviour that depends on the package being its own consumer is not
portable; the drill only passed because the answer happened to be lying around.

## What changed

**Step 4** now presents both outcomes as normal, and shows the story-level `Role:` line as a
literal the Architect can copy. It also states what leaving it off costs: the router falls back to
the Implementor, announces the guess, and posts *"you probably meant to trigger one of its tasks"*
on **every** trigger rather than once. A Branch line with no Role line is the one shape that costs
a run before any work starts.

**The Writer rule is scoped, not softened.** *"Cut one where it seems needed"* would revert to
precisely the failure that produced the rule — asked to predict whether documentation was needed,
the Architect answered "no" on every story ever shaped, and not one Writer task was ever cut.

What changed is **which decision it is making**: the size question in step 4, which it was making
anyway — not "does this deserve a spec", which it has answered wrong every time it was asked. The
discriminator is now stated rather than left to feel:

> **whether a specification needs writing before the code.** If it does, the story divides — cut
> the Writer task first and stop treating it as as-is.

And ambiguity resolves to **divide**: an unnecessary Writer run is one cheap run reporting nothing
to specify; a skipped necessary one is a story shipping with nothing saying what the product now
promises, discovered when the next Tester has nothing to derive from.

**A third note** in *Every task you create* says an as-is story carries the same two lines and the
only difference is which issue the Branch line names — which is the exact test every hook and the
router already run, so nothing new has to be remembered.

## Tests

Six new cases in `tests/test_pure.py`, in the spirit of the existing ones that parse every
`### Sequencing` example — prose review had already passed this contradiction, so it is pinned:

- the as-is story is named as an outcome
- the story-level `Role:` line is shown as a copyable literal
- the Writer rule is scoped **and** still not a judgement inside that scope (asserted both
  directions, so neither the contradiction nor the softening can come back)
- the rule's history survives the rescoping — a rule stripped of its reason is the one a later
  edit softens away
- the discriminator is stated
- ambiguity resolves to divide

All six verified failing against `mainline`'s prompt before the fix.

## Incidental

`tests/test_pure.py` had a stray `if __name__ == "__main__": unittest.main()` in the middle of the
file, so running that module directly never reached the two classes defined below it. Moved to the
end. No effect under `discover`, which is how the gate runs.

## Verification

`python3 -m compileall -q hooks && python3 -m unittest discover -s tests` — **121 passed**.

## Not in scope

The prompt now says what the shapes are. It does not change any hook, schema or routing rule —
`delegate.py` already supported all three, which is why this is a wording defect rather than a
behavioural one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_