### PR TITLE
Drop the classification row that says a task gets no label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,6 @@ covering both, and it does not:
 |---|---|---|---|
 | **routing** | the front-door label, `@claude/<role>` | the maintainer; hooks stamp the trail | what should *happen* to this issue, and what has already run |
 | **classification** | `epic`, `spike`, `bug`, `task`, `story` | anyone filing; the custodial phase fills gaps | what this issue *is* |
-| **classification** | `epic`, `spike`, `bug`, `story` | anyone filing; a hook applies it after the Architect runs | what this issue *is* |
 
 A classification label is durable and derivable, so it survives a run and nothing has to
 re-derive it. ⚠️ **Every kind gets one, `story` included.** An earlier version left a story


### PR DESCRIPTION
`CLAUDE.md`'s two-kinds-of-label table lists `classification` twice:

| labels | who applies |
|---|---|
| `epic`, `spike`, `bug`, `task`, `story` | anyone filing; the custodial phase fills gaps |
| `epic`, `spike`, `bug`, `story` | anyone filing; a hook applies it after the Architect runs |

The second is the superseded version, never deleted — and it reads last, so the document says a task gets no classification label. `team.KIND_LABELS` has five entries including `task`, and `templates/labels.json` ships a `task` label, so the first row is the true one. Dropped the second.

### Scope changed after review

This branch originally also rewrote the `task` description in `templates/labels.json`, which read *"A slice of a story, with its own branch and PR"*. That was **already fixed on mainline** by #41, better than my version and with a new colour from #48 — I had reasoned about it from a checkout 20 commits stale, which is the thing this repo's own directory rules say to fetch before doing. The branch has been rebuilt on current `mainline` with that half dropped; only the table row remains.

### What this does not do

Not a behaviour change — no hook reads either row, so the green suite proves nothing moved rather than proving the fix works. Verified against `team.KIND_LABELS` and `hooks/labels-and-status.py` by reading them, which is the only check available for a documentation contradiction.

### Gate

```
python3 -m unittest discover -s tests    # 121 tests, OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
