### PR TITLE
Let the consumer name its own authoring runtimes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,4 +69,8 @@ jobs:
       allowed_bots: ""
       node: false
       browser: false
+      # ⚠️ This repo is stdlib Python and its gate is `python3 -m unittest`. It is also
+      # the case #46 was found on: with the old fixed npm/npx/node grant, no authoring
+      # role here could run the gate at all.
+      runtimes: "python3"
     secrets: inherit

--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -134,6 +134,13 @@ on:
         description: Install and cache the Playwright chromium before author runs
         type: boolean
         default: false
+      runtimes:
+        description: >-
+          Comma-separated commands the authoring roles may run, so they can execute the
+          consumer's own gate. Each becomes a `Bash(<name>:*)` grant. Defaults to the Node
+          toolchain, which is what every consumer got before this input existed.
+        type: string
+        default: "npm,npx,node"
 
 env:
   NODE_VERSION: 22
@@ -1211,6 +1218,49 @@ jobs:
           echo "list=$list" >> "$GITHUB_OUTPUT"
           echo "roles for this run:${list:- none}"
 
+      # ⚠️ THE CONSUMER'S TOOLCHAIN IS THE CONSUMER'S TO NAME, and for a long time this file
+      # named it: every authoring role was granted `Bash(npm|npx|node:*)` and nothing else, so
+      # an author in a Python-gated repo could not run the gate at all. Measured on run
+      # 32561656056 — the Implementor reimplemented its assertion in `node` and reported, in the
+      # 🔔 Maintainer section, that it had not run the Python suite (#46). That is the ceiling of
+      # the constraint: a role producing a change it cannot verify.
+      #
+      # ⚠️ It broke this package's own stated invariant — *nothing here names a consuming repo,
+      # its branches, its gate or its packages*. A toolchain is the same category as a gate.
+      #
+      # ⚠️ SANITISED, NOT INTERPOLATED RAW. The value lands inside the quoted `--allowedTools`
+      # string, which is line-parsed by the action; an entry carrying a quote, a comma-escape or
+      # a newline could rewrite the flags after it. A consumer already controls its own caller
+      # workflow, so this is not a privilege boundary — it is what stops a typo silently
+      # widening the grant instead of failing.
+      #
+      # ⚠️ The default reproduces the old fixed list exactly, so no existing consumer changes
+      # behaviour by upgrading.
+      - id: runtimes
+        name: Resolve the authoring runtimes
+        env:
+          RUNTIMES: ${{ inputs.runtimes }}
+        run: |
+          grants=""
+          IFS=','
+          for name in $RUNTIMES; do
+            name=$(echo "$name" | tr -d '[:space:]')
+            [ -z "$name" ] && continue
+            case "$name" in
+              *[!a-z0-9_.-]*)
+                echo "::error::runtimes entry '$name' is not a bare command name — allowed: a-z 0-9 . _ -"
+                exit 1 ;;
+            esac
+            grants="$grants,Bash($name:*)"
+          done
+          unset IFS
+          if [ -z "$grants" ]; then
+            echo "::error::runtimes resolved to nothing; an author with no runtime cannot run any gate"
+            exit 1
+          fi
+          echo "grants=$grants" >> "$GITHUB_OUTPUT"
+          echo "authoring runtimes:$grants"
+
       # Install as workflow steps, not from inside a run: this costs Claude zero turns, and
       # without it `tsc` resolves to the runner image's global TypeScript (a different
       # major) and fails on config this repo pins as valid. The Writer is in this list too:
@@ -1379,7 +1429,7 @@ jobs:
           # sub-issue filing: a consumer cannot tell "nothing to report" from "forgot".
           claude_args: |
             --model opus
-            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*)"
+            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*)${{ steps.runtimes.outputs.grants }}"
             --max-turns 80
             --json-schema '${{ steps.schema.outputs.body }}'
 
@@ -1452,7 +1502,7 @@ jobs:
           prompt: ${{ steps.p_designer.outputs.body }}
           claude_args: |
             --model opus
-            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*)"
+            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*)${{ steps.runtimes.outputs.grants }}"
             --max-turns 80
             --json-schema '${{ steps.schema.outputs.body }}'
 
@@ -1522,9 +1572,14 @@ jobs:
           # render an empty fenced block and contradict the prompt, which sends the Tester to
           # the Handoff comments on the story's ISSUE instead.
           prompt: ${{ steps.p_tester.outputs.body }}
+          # ⚠️ THE TESTER GAINED `node` WHEN THE FOUR AUTHORS WERE UNIFIED ONTO ONE GRANT, and
+          # that is a stated widening rather than a side-effect. It previously held `npm`/`npx`
+          # and not `node`, with nothing anywhere saying why — and `npx` already executes node
+          # code, so the omission bounded nothing. Per-role runtime lists were the alternative
+          # and would have made a Python consumer configure four of them.
           claude_args: |
             --model sonnet
-            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
+            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*)${{ steps.runtimes.outputs.grants }}"
             --max-turns 80
             --json-schema '${{ steps.schema.outputs.body }}'
 
@@ -1603,7 +1658,7 @@ jobs:
           # input is maintainer-shaped issues — the trust level of every other authoring role.
           claude_args: |
             --model sonnet
-            --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(node:*)"
+            --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*)${{ steps.runtimes.outputs.grants }}"
             --max-turns 80
             --json-schema '${{ steps.schema.outputs.body }}'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -720,6 +720,40 @@ starting the app and driving it, not reading the source. Withholding `npm`/`npx`
 made the one role that owns the spec unable to produce it, and it failed the expensive way — by
 burning turns on permission denials rather than saying so.
 
+⚠️ **AND THE SHELL THEY DO HOLD IS THE CONSUMER'S TO NAME, WHICH THIS FILE USED TO DO ITSELF.**
+Every authoring role was granted `Bash(npm|npx|node:*)` and nothing else, so an author in a
+Python-gated repo could not run the gate at all — **including in this repo**, whose own gate is
+`python3 -m unittest`. It is a straight violation of the invariant at the top: *nothing here names
+a consuming repo, its branches, its gate or its packages.* A toolchain is the same category as a
+gate.
+⚠️ **The symptom is a role that produces a change it cannot verify**, and reports that in a
+section easy to skip. Measured on run 32561656056: the Implementor reimplemented its assertion in
+`node` against the real data and said plainly, in its 🔔 Maintainer block, that this was not the
+Python suite running (#46). It is milder here, where a maintainer reads the handoff, than in a
+consumer where nobody does before merging. ⚠️ It silently changes what the **Tester** means too —
+a Tester that cannot execute the suite it just wrote is asserting that its tests *should* pass,
+which is the derive-from-the-implementation failure wearing a different hat.
+⚠️ **A `runtimes` input replaces it**, defaulting to `npm,npx,node` so no existing consumer
+changes behaviour, each entry expanded into a `Bash(<name>:*)` grant by a step in the authors job.
+⚠️ **The value is SANITISED, not interpolated raw** — it lands inside the quoted `--allowedTools`
+string, which the action parses line by line, so an entry carrying a quote could rewrite the flags
+after it. A consumer already controls its own caller workflow, so this is not a privilege boundary;
+it is what stops a typo widening the grant instead of failing. ⚠️ **Resolving to nothing fails the
+step**, because an author with no runtime cannot run any gate and the silence is the whole defect.
+⚠️ **`Bash(*)` was never available as the fix.** The Researcher's own history records that a broad
+grant shipped briefly and was a live token-exfiltration path: the action re-injects `GH_TOKEN` and
+`CLAUDE_CODE_OAUTH_TOKEN` into the agent's environment whatever the step declares.
+⚠️ **The four authors now share ONE grant, so the Tester gained `node`** — a stated widening, not
+a side-effect. It held `npm`/`npx` and not `node` with nothing anywhere saying why, and `npx`
+already executes node code, so the omission bounded nothing. Per-role runtime lists were the
+alternative and would make a Python consumer configure four of them.
+⚠️ **The narrow roles are untouched and must stay so**: the Researcher holds no shell by design,
+and the Custodian and Security are allowlisted by subcommand. `runtimes` is for the authoring
+roles alone.
+⚠️ **One toolchain name survives, deliberately unfixed:** Security still holds `Bash(npm audit:*)`.
+That is a dependency-audit capability rather than a gate, so it is a different question — but it is
+the same category of assumption and should be named when someone settles it.
+
 ⚠️ **It is the only role that reads the open web, and the only one whose input the maintainer did
 not write** — which is exactly why **it holds no shell**. No `Bash` of any kind, no `Write`, no
 `npm ci`, no build. It reads (`Read`/`Glob`/`Grep`), it fetches, and it returns JSON.

--- a/README.md
+++ b/README.md
@@ -101,9 +101,15 @@ not happen, never as a failure.
 | `allowed_bots` | no | the dispatch App's login, `<app-slug>[bot]`. Empty admits none |
 | `node` | no | your call — `true` runs `npm ci` before author runs |
 | `browser` | no | your call — `true` installs the Playwright chromium |
+| `runtimes` | no | **your repo's gate** — the commands an author must be able to run. Defaults to `npm,npx,node` |
 
 ⚠️ Name the App in `allowed_bots` **explicitly**. A wildcard lets any external App invoke the
 action with a prompt it controls.
+
+⚠️ Set `runtimes` to whatever your gate actually needs — `python3` for a Python repo, `go`, `cargo`,
+`bundle`, and so on. Each entry becomes a `Bash(<name>:*)` grant for the four authoring roles, and
+they hold no other runtime. An author that cannot run your gate still produces the change; it just
+cannot verify it, and says so in its report rather than failing — which is easy to miss.
 
 ### Secrets — *Settings → Secrets and variables → Actions*
 

--- a/templates/consumer-stub.yml
+++ b/templates/consumer-stub.yml
@@ -56,4 +56,8 @@ jobs:
       allowed_bots: ""
       node: false
       browser: false
+      # The commands an authoring role may run, so it can execute THIS repo's gate.
+      # Each becomes a `Bash(<name>:*)` grant. A Python repo sets "python3"; a Go repo
+      # "go". Leave the default if your gate is npm-driven.
+      runtimes: "npm,npx,node"
     secrets: inherit

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import re
 import unittest
@@ -164,6 +165,186 @@ class ReadmeDocumentsEveryInput(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheConsumerNamesItsOwnToolchain(unittest.TestCase):
+    """⚠️ #46: every authoring role was granted `Bash(npm|npx|node:*)` and nothing else, so an
+    author in a Python-gated repo could not run the gate — including in THIS repo, whose gate is
+    `python3 -m unittest`. Measured on run 32561656056: the Implementor reimplemented its
+    assertion in `node` and reported that it had not run the Python suite. That is the ceiling of
+    the constraint — a role producing a change it cannot verify.
+
+    It also broke the package's own invariant: *nothing here names a consuming repo, its branches,
+    its gate or its packages.* A toolchain is the same category as a gate."""
+
+    # ⚠️ AN AUTHORING STEP IS ONE THAT CARRIES THE HANDOFF SCHEMA, not one whose tool string
+    # happens to start `Edit,Write`. Matching on the shape of the string caught the ARCHITECT,
+    # which holds `Read,Edit,Write` to rewrite an issue body and correctly has no runtime — it
+    # writes no code and runs no gate. `--json-schema` is exactly the four roles that do.
+    @staticmethod
+    def _claude_args_blocks(text):
+        """Each `claude_args: |` body, taken to the first line that dedents out of it.
+        ⚠️ Deliberately NOT one regex: `\\s{12}` matches newlines, so a greedy version ran past
+        the end of a step and swept the next role's flags into the same block."""
+        blocks = []
+        lines = text.splitlines()
+        for i, line in enumerate(lines):
+            if line.strip() != "claude_args: |":
+                continue
+            body = []
+            for nxt in lines[i + 1:]:
+                if nxt.strip() and not nxt.startswith(" " * 12):
+                    break
+                body.append(nxt)
+            blocks.append("\n".join(body))
+        return blocks
+
+    # ⚠️ AN AUTHORING ROLE IS ONE THAT RUNS IN THE `authors` JOB. Two narrower-looking
+    # discriminators were tried and both were wrong: matching `Edit,Write` swept in the
+    # ARCHITECT, which rewrites issue bodies and runs no gate; matching `--json-schema` swept in
+    # the CUSTODIAN and the RESEARCHER, which also return JSON. The job boundary is the thing
+    # that actually means "writes code, needs the consumer's gate".
+    @staticmethod
+    def _job(text, name):
+        """One job's lines, from its key to the next key at the same indent.
+        ⚠️ Line-walked rather than regexed — a lookahead for the NEXT job assumed a blank line
+        before it and silently matched nothing when there wasn't one."""
+        lines, out, inside = text.splitlines(), [], False
+        for line in lines:
+            if line == f"  {name}:":
+                inside = True
+                continue
+            if inside and re.match(r"^  \S.*:$", line):
+                break
+            if inside:
+                out.append(line)
+        assert out, f"job {name} not found"
+        return "\n".join(out)
+
+    AUTHORS_JOB = _job.__func__(TEAM, "authors")
+
+    AUTHOR_TOOLS = [
+        re.search(r'--allowedTools "([^"]*)"', b).group(1)
+        for b in _claude_args_blocks.__func__(AUTHORS_JOB)
+        if "--allowedTools" in b
+    ]
+
+    def test_all_four_authoring_roles_are_found(self):
+        """Guards the extraction above: if it stops matching, every assertion below passes
+        vacuously — and a test that cannot fail is worse than no test."""
+        self.assertEqual(len(self.AUTHOR_TOOLS), 4, self.AUTHOR_TOOLS)
+
+    def test_the_architect_is_not_swept_in(self):
+        """It rewrites issue bodies, so it holds `Read,Edit,Write` and looks like an author to
+        anything matching on that. It runs no gate and must gain no runtime."""
+        self.assertIn('--allowedTools "Read,Edit,Write,Bash(gh:*),Bash(git:*)"', TEAM)
+
+    def test_no_author_allowlist_hard_codes_a_toolchain(self):
+        for tools in self.AUTHOR_TOOLS:
+            with self.subTest(tools=tools):
+                for named in ("npm", "npx", "node", "python", "go:", "cargo", "bundle"):
+                    self.assertNotIn(named, tools,
+                                     f"{named} is a consumer's toolchain; it belongs in `runtimes`")
+
+    def test_every_author_takes_the_resolved_grant(self):
+        for tools in self.AUTHOR_TOOLS:
+            with self.subTest(tools=tools):
+                self.assertIn("${{ steps.runtimes.outputs.grants }}", tools)
+
+    def test_the_authors_still_hold_git_and_gh_unconditionally(self):
+        """`runtimes` widens the gate, it does not replace what an author has always needed:
+        the landing hooks are not the only thing that touches git, and `gh` is how a role reads
+        its own issue."""
+        for tools in self.AUTHOR_TOOLS:
+            with self.subTest(tools=tools):
+                self.assertIn("Bash(git:*)", tools)
+                self.assertIn("Bash(gh:*)", tools)
+
+    def test_the_default_reproduces_the_old_fixed_list(self):
+        """⚠️ A consumer upgrading past this change must see no behaviour difference. The old
+        grant was npm, npx and node; the default has to be exactly that, or the release breaks
+        every existing install."""
+        self.assertRegex(TEAM, r'runtimes:\n\s+description:[\s\S]*?default: "npm,npx,node"')
+
+    def test_the_stub_and_the_self_install_both_declare_it(self):
+        self.assertIn("runtimes:", STUB)
+        self.assertIn('runtimes: "python3"', SELF,
+                      "this repo's gate is python3 — it is the case #46 was found on")
+
+    def test_the_narrow_role_allowlists_are_untouched(self):
+        """The Researcher holds no shell BY DESIGN, and the Custodian and Security are
+        allowlisted by subcommand. `runtimes` is for the authoring roles only — widening any of
+        these three would undo a deliberate bound."""
+        self.assertIn('--allowedTools "Read,WebSearch,WebFetch"', TEAM)
+        for narrow in ("Bash(gh issue view:*)", "Bash(gh pr diff:*)"):
+            self.assertIn(narrow, TEAM)
+        self.assertNotIn('Read,WebSearch,WebFetch${{', TEAM)
+
+
+class TheRuntimesResolverActuallyRuns(unittest.TestCase):
+    """⚠️ PINNING THE YAML PROVES THE WIRING, NOT THE BEHAVIOUR. The resolver is a shell script
+    that sanitises consumer-supplied text before it lands inside a quoted `--allowedTools` string
+    the action parses line by line. A bad entry must fail the step, not silently rewrite the flags
+    after it — so the script itself is extracted and executed here."""
+
+    def script(self):
+        """The `run:` body of the `id: runtimes` step, dedented."""
+        block = re.search(
+            r"- id: runtimes\n(?:.*\n)*?        run: \|\n((?:          .*\n|\n)+)", TEAM)
+        self.assertIsNotNone(block, "could not find the runtimes step's run: body")
+        return "".join(l[10:] if l.startswith(" " * 10) else l
+                       for l in block.group(1).splitlines(keepends=True))
+
+    def resolve(self, value):
+        import subprocess
+        return subprocess.run(
+            ["bash", "-c", self.script()],
+            capture_output=True, text=True,
+            env={**os.environ, "RUNTIMES": value, "GITHUB_OUTPUT": self.out},
+        )
+
+    def setUp(self):
+        import tempfile
+        fd, self.out = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(os.unlink, self.out)
+
+    def grants(self, value):
+        r = self.resolve(value)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        written = open(self.out).read()
+        return dict(l.split("=", 1) for l in written.splitlines() if "=" in l)["grants"]
+
+    def test_the_default_expands_to_the_old_fixed_list(self):
+        self.assertEqual(self.grants("npm,npx,node"),
+                         ",Bash(npm:*),Bash(npx:*),Bash(node:*)")
+
+    def test_a_single_runtime_works(self):
+        self.assertEqual(self.grants("python3"), ",Bash(python3:*)")
+
+    def test_surrounding_whitespace_is_tolerated(self):
+        self.assertEqual(self.grants(" python3 , go "), ",Bash(python3:*),Bash(go:*)")
+
+    def test_an_empty_entry_is_skipped_rather_than_expanded(self):
+        self.assertEqual(self.grants("python3,,go"), ",Bash(python3:*),Bash(go:*)")
+
+    def test_an_entry_that_could_rewrite_the_flags_fails_the_step(self):
+        """The value sits inside `--allowedTools "…"`. A quote, or anything that reaches the
+        parser as a new argument, could widen the grant far past what the consumer wrote."""
+        for hostile in ['node:*)",Bash', "node'", 'node"', "node;rm -rf /", "Bash(node:*)"]:
+            with self.subTest(entry=hostile):
+                r = self.resolve(hostile)
+                self.assertNotEqual(r.returncode, 0, f"{hostile!r} was accepted")
+                self.assertIn("::error::", r.stdout + r.stderr)
+
+    def test_resolving_to_nothing_fails_rather_than_granting_nothing(self):
+        """⚠️ An author with no runtime cannot run any gate. Failing loudly beats a run that
+        silently cannot verify anything — that silence is the whole of #46."""
+        for empty in ("", "  ", ",,,"):
+            with self.subTest(value=repr(empty)):
+                r = self.resolve(empty)
+                self.assertNotEqual(r.returncode, 0)
+                self.assertIn("::error::", r.stdout + r.stderr)
 
 
 class ReleasePins(unittest.TestCase):


### PR DESCRIPTION
Story PR for `46-runtimes-input`.

**Worked as-is** — one input, one resolver step, and the four call sites it feeds.

Closes #46

## The defect

Every authoring role was granted `Bash(npm|npx|node:*)` and nothing else, so an author in a
Python-gated repo could not run the gate — **including in this repo**, whose own gate is
`python3 -m unittest`.

It is a straight violation of the invariant at the top of CLAUDE.md:

> **Invariants.** Nothing here names a consuming repo, its branches, its gate or its packages.

A toolchain is the same category as a gate.

**The symptom is a role that produces a change it cannot verify**, and says so in a section that
is easy to skip. On run [32561656056](https://github.com/matt-whitaker/claude-team/actions/runs/32561656056)
the Implementor reimplemented its assertion in `node` against the real data and reported plainly,
in its 🔔 Maintainer block, that this was not the Python suite running. Milder here, where a
maintainer reads the handoff, than in a consumer where nobody does before merging.

⚠️ It also changes what the **Tester** means. A Tester that cannot execute the suite it just wrote
is asserting that its tests *should* pass — the derive-from-the-implementation failure wearing a
different hat.

## The change

A `runtimes` input, defaulting to `npm,npx,node` so **no existing consumer changes behaviour on
upgrade**. A step in the authors job expands each entry into a `Bash(<name>:*)` grant, and the
four author `--allowedTools` lines read it.

```yaml
runtimes: "python3"     # this repo
runtimes: "npm,npx,node" # the default, and the stub's value
```

**Sanitised, not interpolated raw.** The value lands inside the quoted `--allowedTools` string,
which the action parses line by line, so an entry carrying a quote could rewrite the flags after
it. A consumer already controls its own caller workflow, so this is not a privilege boundary — it
is what stops a typo silently widening the grant instead of failing.

**Resolving to nothing fails the step.** An author with no runtime cannot run any gate, and that
silence is the whole of #46.

`Bash(*)` was never available as the fix: the Researcher's own history records that a broad grant
shipped briefly and was a live token-exfiltration path, since the action re-injects `GH_TOKEN` and
`CLAUDE_CODE_OAUTH_TOKEN` into the agent's environment whatever the step declares.

## One stated widening

The four authors now share one grant, so **the Tester gains `node`**. Calling it out rather than
letting it ride: it held `npm` and `npx` but not `node`, with nothing anywhere saying why, and
`npx` already executes node code — so the omission bounded nothing. Per-role runtime lists were
the alternative and would make a Python consumer configure four of them.

**The narrow roles are untouched, and a test pins that**: the Researcher holds no shell by design,
and the Custodian and Security are allowlisted by subcommand. `runtimes` is for the authoring
roles alone.

## Left alone deliberately

Security still holds `Bash(npm audit:*)` — the one remaining toolchain name. That is a
dependency-audit capability rather than a gate, so it is a different question; named in CLAUDE.md
rather than swept into this change.

## Tests

14 new cases across two classes, all verified failing against `mainline` (22 failures there, 0
here).

`TheConsumerNamesItsOwnToolchain` pins the wiring — no author allowlist hard-codes a toolchain,
all four take the resolved grant, git and gh stay unconditional, the default reproduces the old
fixed list exactly, the stub and self-install both declare it, the narrow roles are unchanged.

`TheRuntimesResolverActuallyRuns` pins the **behaviour**: pinning YAML proves the wiring, not that
the sanitiser works. The resolver's `run:` body is extracted from the workflow and executed —
including the entries that must fail (`node:*)",Bash`, embedded quotes, a shell metacharacter,
and an empty result).

⚠️ Two narrower discriminators for "an authoring role" were tried and rejected while writing
these, both caught by a deliberate `assertEqual(len(...), 4)` guard rather than passing vacuously:

- matching `Edit,Write` swept in the **Architect**, which rewrites issue bodies and runs no gate
- matching `--json-schema` swept in the **Custodian** and **Researcher**, which also return JSON

The job boundary is the one that actually means "writes code, needs the consumer's gate", and the
extraction is line-walked rather than regexed — a greedy `\s{12}` ran past the end of a step and
swept the next role's flags into the same block.

## Verification

`python3 -m compileall -q hooks && python3 -m unittest discover -s tests` — **135 passed**.
All three workflow files re-parsed as YAML after editing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_