### PR TITLE
Correct two claims at the top that stopped being true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,18 @@ deliberately stale refs, the condition sandboxes kept lacking.
 ⚠️ **Releasing**: check out mainline, flip every pin (`TEAM_REF`, the in-workflow `@refs`,
 `load-prompt`'s default, the stub template) from `mainline` to `vN` in one commit, run the suite
 (`ReleasePins` asserts the agreement), tag that commit `vN`, push the tag, and **do not merge the
-release commit** — mainline keeps its canary pins. Consumers pin `@vN`; brewdocs.beer alone tracks
-`@mainline`.
+release commit** — mainline keeps its canary pins. Consumers pin `@vN`; a repo whose job is to
+exercise the engine tracks `@mainline` instead — brewdocs.beer as the canary, `claude-team-example`
+as the drill target, and this repo's own stub, which `SelfInstall` pins there permanently.
+⚠️ **brewdocs.beer-kb tracks `@mainline` without that justification** — it ships product, so the rule
+says pin it. Kept on the edge by the maintainer's call, provisionally.
 
-⚠️ **Phase 2 state**: `team.yml` is a reusable workflow (`on: workflow_call`). A consumer holds
+⚠️ **The consumer contract**: `team.yml` is a reusable workflow (`on: workflow_call`). A consumer holds
 the frozen stub (`templates/consumer-stub.yml`) plus a `.claude-team/` directory — `prompts/`
 overlays (`_shared.md` required) and an optional executable `setup.sh`. Inputs: `project_owner`,
-`project_number`, `allowed_bots`, `node`, `browser`. ⚠️ **Two pins move together**: the consumer's
+`project_number`, `allowed_bots`, `node`, `browser`, `runtimes`. ⚠️ **Two pins move together**: the consumer's
 `@ref` on the workflow, and `TEAM_REF` inside it (what the jobs fetch at run time) — release
-tooling owns keeping them equal. No production consumer is converted yet (brewdocs.beer is
-Phase 3).
+tooling owns keeping them equal.
 
 **Purpose.** A portable Claude/GitHub role team: the prompts each role runs on, the scripted
 hooks around them, and the handoff contract between them. Consumed by pointing a workflow at


### PR DESCRIPTION
Two claims in the first screenful of `CLAUDE.md` that stopped being true. A new reader meets both before anything else.

### The Phase 2 block

> **No production consumer is converted yet (brewdocs.beer is Phase 3).**

All five consumers are on the stub. brewdocs.beer converted in #1212 and has taken two stub changes since (#1230, #1237).

The history is **dropped rather than corrected** — a count of converted consumers goes stale the moment there is a sixth, and "Phase 2 state" described a migration that finished. The block is now "the consumer contract", which is what it actually documents.

**The same block listed five inputs and there are six.** `runtimes` landed in #51, and this block is where a consumer looks to find out what it can configure, so the omission is the expensive kind — it went stale one PR after the input shipped.

That is an argument for cutting the enumeration and pointing at the stub instead; **not taken here**, on the maintainer's call. Three places already list these inputs (`team.yml`, `templates/consumer-stub.yml`, `README.md`) and a fourth pointer has its own cost.

### The releasing block

> Consumers pin `@vN`; **brewdocs.beer alone tracks `@mainline`.**

Checked against each repo's `origin/mainline`, not a local checkout:

| repo | pin | reason |
|---|---|---|
| brewdocs.beer | `@mainline` | the canary |
| claude-team | `@mainline` | self-install; `SelfInstall` asserts it |
| claude-team-example | `@mainline` | the drill target |
| brewdocs.beer-kb | `@mainline` | **none** |
| fantasy-football | `@v1.1` | the only consumer the old sentence described |

Four track the edge and one pins. Three of the four have a reason that was never written here, so the sentence made two correct configurations read as drift.

It now states **the rule rather than a roster**, since a roster goes stale the same way: *a repo whose job is to exercise the engine tracks `@mainline`.*

**brewdocs.beer-kb is the exception and is named as one.** It ships product, so the rule says pin it; the maintainer's call is to keep it on the edge for now. Recorded as **provisional** rather than dressed up as a second canary, so whoever reads it next knows a decision was made and that it is still open.

### Gate

```
python3 -m unittest discover -s tests    # 142 tests, OK
```

Documentation only — no hook reads either block, so the green suite proves nothing moved rather than proving the fix works. The pins were verified by reading five repos' remote refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
