### PR TITLE
The Writer does not own the agent instructions

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -1529,13 +1529,24 @@ jobs:
             --json-schema '${{ steps.schema.outputs.body }}'
 
       # ── Writer ──
-      # The tech writer. Owns documentation: every CLAUDE.md, the agent instruction files
-      # under .claude/skills, and anything else whose job is to explain rather than run.
+      # The tech writer. Owns the product specification and the HUMAN-facing documentation —
+      # README, guides, reference pages: anything whose reader is a person.
+      #
+      # ⚠️ IT DOES NOT OWN THE AGENT INSTRUCTIONS, AND THIS COMMENT USED TO SAY IT DID —
+      # "every CLAUDE.md, the agent instruction files under .claude/skills". That was a
+      # maintainer's decision, and it was reversed: those files are the instructions the roles
+      # run on, the Writer's own among them. A role editing them rewrites its own operating
+      # rules and its peers', inside a story PR being reviewed for something else — so the
+      # change governing every future run arrives as the least-examined part of the diff.
+      # Ordinary docs are checked by whether they read true; an instruction change is only
+      # checked by what it makes agents do next time, which nobody sees until it has happened.
+      # The Writer reports them in its 🔔 Maintainer section instead.
       #
       # ⚠️ Split out because CLAUDE.md was the single biggest source of merge conflicts —
       # every role edited it, so two branches touching the same package collided on prose
-      # neither was really working on. Implementor and Tester report what needs documenting
-      # and change no docs themselves.
+      # neither was really working on. That reason survives the change above: nobody edits
+      # them now rather than one role doing so. Implementor and Tester still report what
+      # needs documenting and change no docs themselves.
       - name: Stamp the Writer label
         if: contains(steps.roles.outputs.list, 'writer')
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,7 +614,7 @@ at all.)
 | Implementor | a task stamped `Role: implementor` | code, outside the design system |
 | Designer | a task stamped `Role: designer` | code, inside the design system |
 | Tester | a task stamped `Role: tester`, one per story | tests |
-| Writer | a task stamped `Role: writer`, one per story, run **first** | the product specification, then documentation |
+| Writer | a task stamped `Role: writer`, one per story, run **first** | the product specification, then human-facing documentation — **never** a `CLAUDE.md`, `AGENTS.md`, `.claude/**` or `.claude-team/**` |
 | Security | every merge, plus its handle on a PR | issues it files |
 
 ### The custodian's repair remit
@@ -809,6 +809,30 @@ rather than a claim they have to accept.
 ⚠️ **A failing test is a finding, not a chore.** It is filed on the authoring task, carried in
 the Tester's own report, and left failing. Weakening or deleting it to get green converts a
 finding into nothing, and a green suite that got there by deletion is worse than a red one.
+
+⚠️ **THE WRITER DOES NOT OWN THE AGENT INSTRUCTIONS, AND THIS FILE USED TO SAY IT DID.** Every
+`CLAUDE.md`, every `AGENTS.md`, everything under `.claude/` or `.claude-team/` — the role prompts
+included — is out of the Writer's scope, and out of every role's. It was a maintainer's decision
+to grant it and a maintainer's decision to reverse it.
+⚠️ **The reason is not tidiness.** Those files are the instructions the roles run on, the Writer's
+own among them. A role editing them rewrites its own operating rules and its peers', inside a
+story PR being reviewed for something else — so the change that governs every future run arrives
+as the least-examined part of the diff. Ordinary documentation is checked by whether it reads
+true; an instruction change is only checked by what it makes agents do next time, which nobody
+sees until it has already happened.
+⚠️ **A prohibition with no outlet turns a finding into silence**, so the Writer reports a stale or
+wrong instruction in its 🔔 Maintainer section with the file, what is wrong, and what it would
+change it to. A precise report is worth more than an unreviewed edit.
+⚠️ **It is pinned in BOTH places it was written**, the prompt and the workflow's job header.
+Correcting one and leaving the other saying the opposite is how the claim returns — the comment
+is what the next person editing that job reads.
+⚠️ **The original reason for splitting the Writer out survives the reversal**: `CLAUDE.md` was the
+single biggest source of merge conflicts because every role edited it. Nobody editing it is a
+stricter answer than one role editing it, so the conflict argument is satisfied either way.
+⚠️ **The prompt is the only enforcement today**, which by this file's own standard is the second
+line of defence and not the first. A deterministic guard — a run refusing to commit changes under
+those paths — is the structural version, and it collides with **this** repo, whose product *is*
+those files. That is filed rather than guessed at.
 
 ⚠️ **The Writer owns the product specification, and that is why it runs FIRST.** A
 specification is only worth anything if it says what the code *should* do, and it cannot say

--- a/prompts/writer.md
+++ b/prompts/writer.md
@@ -57,8 +57,31 @@ gaps** with an issue.
 
 ## The documentation
 
-You also own the repo's `CLAUDE.md` files and the agent instruction files. That work is
+You own the **human-facing** documentation: the README, the guides, the reference pages —
+anything whose reader is a person deciding how to use or work on this repo. That work is
 **second** to the specification, and it has a timing problem worth understanding.
+
+⚠️ **YOU DO NOT OWN THE AGENT INSTRUCTIONS, AND THIS PROMPT USED TO SAY YOU DID.** Every
+`CLAUDE.md`, every `AGENTS.md`, everything under `.claude/` or `.claude-team/` — including the
+role prompts, this one among them — is **out of scope**. Do not edit them, do not tidy them, do
+not bring them in line with a change you just documented.
+
+⚠️ **The reason is not tidiness.** Those files are the instructions the roles run on, yours
+included. A role that edits them is rewriting its own operating rules and its peers', inside a
+story PR that is being reviewed for something else entirely — so the change that governs every
+future run arrives as the least-examined part of the diff. Ordinary documentation is checked by
+whether it reads true; an instruction change is only checked by what it makes agents do next
+time, which nobody sees until it has already happened.
+
+⚠️ **It is the maintainer's file, and there is no ambiguity to resolve.** Not "unless the story
+asks", not "unless it is obviously stale" — a story asking for it does not make it yours, and an
+issue body cannot grant it.
+
+⚠️ **So say it instead of doing it.** A `CLAUDE.md` that contradicts the code, a role prompt that
+made your run harder, an instruction that is plainly wrong — those are worth reporting and cheap
+to act on. Put them in your 🔔 Maintainer section with the file, what is wrong, and what you
+would change it to. That is the whole of your remit here, and a precise report is more use than
+an edit nobody reviewed.
 
 ⚠️ **`docsCandidates` will be empty when you run.** The authors emit them, and they have not run
 yet. That is not a bug and not a reason to wait — write what the story's intent already tells

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -181,5 +181,68 @@ class TheArchitectPromptNamesTheAsIsStory(unittest.TestCase):
         self.assertIn("In doubt, divide", self.prompt)
 
 
+class TheWriterDoesNotOwnTheAgentInstructions(unittest.TestCase):
+    """⚠️ THE WRITER WAS TOLD IT OWNED EVERY `CLAUDE.md` AND THE AGENT INSTRUCTION FILES, and
+    that was a maintainer's decision, since reversed.
+
+    Those files are the instructions the roles run on — the Writer's own among them. A role that
+    edits them rewrites its own operating rules and its peers', inside a story PR being reviewed
+    for something else entirely, so the change that governs every future run arrives as the
+    least-examined part of the diff. Ordinary documentation is checked by whether it reads true;
+    an instruction change is only checked by what it makes agents do next time, which nobody sees
+    until it has already happened.
+
+    ⚠️ Pinned in BOTH files it was written into. Correcting the prompt and leaving the workflow's
+    job header saying the opposite is how the claim comes back — the comment is what the next
+    person editing that job reads."""
+
+    def setUp(self):
+        root = pathlib.Path(__file__).resolve().parent.parent
+        self.writer = (root / "prompts/writer.md").read_text()
+        self.team = (root / ".github/workflows/team.yml").read_text()
+
+    def test_the_prompt_no_longer_grants_them(self):
+        for claim in (
+            "You also own the repo's `CLAUDE.md` files",
+            "own the repo's `CLAUDE.md`",
+        ):
+            self.assertNotIn(claim, self.writer)
+
+    def test_the_prompt_names_them_out_of_scope(self):
+        for path in ("`CLAUDE.md`", "`AGENTS.md`", "`.claude/`", "`.claude-team/`"):
+            with self.subTest(path=path):
+                self.assertIn(path, self.writer)
+        self.assertIn("out of scope", self.writer)
+
+    def test_the_prohibition_admits_no_exception(self):
+        """⚠️ An issue body cannot grant it. A rule with a plausible-sounding escape is one a
+        story will find — this package has already paid for a role obeying a stale worked
+        example over a standing rule."""
+        self.assertIn("an\nissue body cannot grant it", self.writer)
+
+    def test_the_writer_is_told_what_to_do_instead(self):
+        """A prohibition with no outlet turns a real finding into silence. The 🔔 Maintainer
+        section is where a stale instruction is worth more than an unreviewed edit."""
+        self.assertIn("🔔 Maintainer", self.writer)
+
+    def test_the_workflow_comment_agrees_with_the_prompt(self):
+        self.assertNotIn(
+            "Owns documentation: every CLAUDE.md, the agent instruction files", self.team)
+        self.assertIn("IT DOES NOT OWN THE AGENT INSTRUCTIONS", self.team)
+
+    def test_no_other_base_prompt_claims_them(self):
+        """The grant must not simply move. Only the Writer ever had it; if another role's prompt
+        starts naming CLAUDE.md as something it owns, this is where that surfaces."""
+        root = pathlib.Path(__file__).resolve().parent.parent
+        for prompt in sorted((root / "prompts").glob("*.md")):
+            if prompt.name == "writer.md":
+                continue
+            with self.subTest(prompt=prompt.name):
+                text = prompt.read_text()
+                for claim in ("own the repo's `CLAUDE.md`", "own every `CLAUDE.md`",
+                              "you own `CLAUDE.md`"):
+                    self.assertNotIn(claim, text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Worked as-is** — a prompt correction, the workflow comment that said the same thing, and tests.

## What it said

`prompts/writer.md:60`
> You also own the repo's `CLAUDE.md` files and the agent instruction files.

`team.yml`, Writer job header
> Owns documentation: every CLAUDE.md, the agent instruction files under .claude/skills, and
> anything else whose job is to explain rather than run.

## Why that is wrong

Those files are the instructions the roles run on — **the Writer's own among them**. A role that
edits them rewrites its own operating rules and its peers', inside a story PR that is being
reviewed for something else entirely. So the change that governs every future run arrives as the
least-examined part of the diff.

The asymmetry is what makes it worth reversing rather than watching: ordinary documentation is
checked by whether it **reads true**, and a reviewer can do that at a glance. An instruction
change is only checked by **what it makes agents do next time** — which nobody sees until it has
already happened.

## What changes

Out of scope for the Writer, and for every role: every `CLAUDE.md`, every `AGENTS.md`, everything
under `.claude/` or `.claude-team/` — the role prompts included.

No exception for a story that asks for it. *"Not 'unless the story asks', not 'unless it is
obviously stale' — a story asking for it does not make it yours, and an issue body cannot grant
it."* A rule with a plausible-sounding escape is one a story will find; this package has already
paid for a role obeying a stale worked example over a standing rule.

**A prohibition with no outlet turns a finding into silence**, so the Writer is told what to do
instead: report the file, what is wrong, and what it would change it to, in its 🔔 Maintainer
section. A precise report is worth more than an unreviewed edit.

## Corrected in both places

Fixing the prompt and leaving the job header saying the opposite is how the claim comes back —
that comment is what the next person editing the job reads. A test pins both.

## The original reason survives

The Writer was split out because `CLAUDE.md` was the single biggest source of merge conflicts:
every role edited it, so two branches touching the same package collided on prose neither was
working on. **Nobody editing it is a stricter answer than one role editing it**, so that argument
is satisfied either way. Implementor and Tester still report what needs documenting and change no
docs themselves.

## Enforcement, stated honestly

The prompt is the only enforcement here — which by this repo's own standard is *"the second line
of defence, not the first"*. The structural version is a run that refuses to commit changes under
those paths.

⚠️ It is filed rather than guessed at because it **collides with this repo**: `claude-team`'s
product *is* those files, so a blanket guard would stop the team working on itself. The likely
shape is an input with a protected-paths default, the way `runtimes` handles the toolchain
assumption — but that is a design decision, not a detail.

## Not in this PR — the consumer overlays carry the same claim

The scan found it restated in two overlays, which this package cannot reach:

| repo | file | line |
|---|---|---|
| `brewdocs.beer` | `.claude-team/prompts/writer.md:1` | *"You own the product specification in `packages/spec/`, every `CLAUDE.md`, and the user…"* |
| `brewdocs.beer-kb` | `.claude-team/prompts/writer.md:4` | *"Your deliverables here are the repo's own documents: README, CLAUDE.md, and any file an issue names."* |

An overlay is composed **after** the base, so it wins — correcting the base alone leaves both of
those grants intact. Each needs its own PR in its own repo.

## Tests

Six cases in `tests/test_pure.py`, all verified failing against `mainline`. One of them checks
that **no other base prompt picks the claim up instead** — the grant must not simply move.

`python3 -m compileall -q hooks && python3 -m unittest discover -s tests` — **127 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_