### PR TITLE
Give a returning consumer a path, and a changelog that answers their question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# CHANGELOG — what a consumer has to do
+
+⚠️ **This is not a merge log, and turning it into one destroys its only purpose.** A consumer
+reading it has exactly one question — *do I have to do something?* — and a list of PR titles
+cannot answer it. Entries name **consumer-side consequences**, or say plainly that there are none.
+
+⚠️ **Every version heading carries an `**Action required:**` line, and a test asserts it.** `no` is
+the commonest and most valuable answer: a release nobody has to act on should say so in one word
+rather than leaving a reader to diff the tag themselves.
+
+⚠️ **Write the entry in the PR that causes it, not at release time.** Reconstructing consumer
+impact from a merge log is exactly the work this file exists to remove, and it is done worst by
+whoever is trying to cut a tag. `## Unreleased` is always open for that reason.
+
+The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
+
+---
+
+## Unreleased
+
+**Action required:** yes — one stub input, one label re-sync, one overlay check.
+
+- **The stub gains a `runtimes` input.** It names the commands an authoring role may run, so it
+  can execute *your* gate. It defaults to `npm,npx,node` — exactly the fixed grant every consumer
+  had before — so **an unchanged stub keeps working**. Set it if your gate is not npm-driven
+  (`python3`, `go`, `cargo`, `bundle`). Until you do, an author in such a repo produces changes it
+  cannot verify and says so in a report section that is easy to miss.
+- **⚠️ Re-run the label loop (§4).** `story`, `task` and `spike` changed colour so no
+  classification label shares one with a routing label. A pin bump cannot carry this — labels live
+  in GitHub, not in the clone.
+- **⚠️ Check your Writer overlay.** The base prompt no longer gives any role ownership of
+  `CLAUDE.md`, `AGENTS.md`, `.claude/**` or `.claude-team/**`. An overlay composes *after* the
+  base, so an overlay that still grants them **wins over this change** and nothing here can reach
+  it. Two known cases in the fleet at the time of writing.
+- **The Architect prompt now names the as-is story** — a story left whole, carrying its own
+  `Branch:` line and a `Role:` stamp. No consumer action; it is the shaping side of a path routing
+  already supported. Expect fewer unnecessary Writer tasks on small stories.
+- **Story PRs and landings report their failures.** `open-story-pr.py` now says what `gh` refused
+  and names the two usual causes; `finish-pr.py` no longer reports landed work as stranded. No
+  action — but if you have been opening story PRs by hand, the next failure will tell you why.
+
+## v1.1
+
+**Action required:** unknown — this file did not exist yet.
+
+Not reconstructed. 24 commits separate `v1.1` from the entry above, and inferring consumer impact
+from them after the fact is guesswork of exactly the kind this file replaces. A consumer upgrading
+across this boundary should follow §0 in full rather than trust a summary written backwards.
+
+## v1
+
+**Action required:** n/a — the first release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,43 @@ which once silently shadowed a stub), imports the pure text helpers from the *re
 they cannot drift, and runs every git-touching case against real repositories — including
 deliberately stale refs, the condition sandboxes kept lacking.
 
-⚠️ **Releasing**: check out mainline, flip every pin (`TEAM_REF`, the in-workflow `@refs`,
+⚠️ **Releasing**: check out mainline, rename `CHANGELOG.md`'s `## Unreleased` heading to `## vN`
+and open a fresh empty one above it, flip every pin (`TEAM_REF`, the in-workflow `@refs`,
 `load-prompt`'s default, the stub template) from `mainline` to `vN` in one commit, run the suite
 (`ReleasePins` asserts the agreement), tag that commit `vN`, push the tag, and **do not merge the
 release commit** — mainline keeps its canary pins. Consumers pin `@vN`; a repo whose job is to
 exercise the engine tracks `@mainline` instead — brewdocs.beer as the canary, `claude-team-example`
 as the drill target, and this repo's own stub, which `SelfInstall` pins there permanently.
+⚠️ **A RELEASE IS NOT FINISHED WHEN THE TAG IS PUSHED — the consumer half was never written down
+at all.** `ONBOARDING.md` installed and never re-installed: every step was written for a fresh
+target, so a session pointed at an installed repo had no instruction for the case it was in, and
+"upgrade" meant bump the ref and hope. §0 is that path, and `CHANGELOG.md` is what makes it
+answerable.
+⚠️ **THE CHANGELOG IS CONSUMER-FACING OR IT IS WORTHLESS.** A list of merged PRs cannot answer the
+only question a consumer has — *must I act?* — so every version heading carries an explicit
+`**Action required:**` line and a test asserts it. `no` is the commonest answer and the most
+valuable one.
+⚠️ **A file rather than the tag's GitHub release notes**, which was the open question. Three
+reasons, and the third is the deciding one: a session doing an upgrade is already in the clone; a
+release note needs a network call and an API that can drop mid-session; and **a file is testable**,
+which is this package's standard for anything load-bearing. `python3 -m unittest` cannot assert
+anything about a release note.
+⚠️ **The entry is written in the PR that causes it, not at release time.** Reconstructing consumer
+impact from a merge log is exactly the work the file exists to remove, and it is done worst by
+whoever is trying to cut a tag — which is why `## Unreleased` stays permanently open. ⚠️ `v1.1`'s
+entry says *unknown* rather than a summary written backwards; 24 commits separate it from the next
+entry and inferring their impact after the fact is the guesswork this replaces.
+⚠️ **AND A PIN CANNOT EXPRESS REPO STATE, which is the half no version number reaches.** Labels
+live in GitHub, not in the clone — so no ref bump has ever touched them, and this repo's own
+`story` and `task` sat identical at `0E8A16` with empty descriptions while `templates/labels.json`
+said otherwise. The one step already written to be idempotent is the one that drifted, because
+nothing told anyone to re-run it. §0 re-runs it unconditionally, along with the board and the
+Actions settings.
+⚠️ **An overlay that contradicts a tightened base rule is the other thing a bump cannot fix.** An
+overlay composes *after* the base and therefore **wins**, so a base change narrowing what a role
+may do reaches nothing while the overlay still grants it. Measured: the Writer's scope was
+corrected here and two consumer overlays went on granting it. §0 says to grep for the old grant
+whenever an entry reports a narrowed scope.
 ⚠️ **brewdocs.beer-kb tracks `@mainline` without that justification** — it ships product, so the rule
 says pin it. Kept on the edge by the maintainer's call, provisionally.
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -8,6 +8,66 @@ the workflow from the default branch.
 
 Private targets are supported (since `v1.1`). Public and private differ in nothing below.
 
+⚠️ **If the target is ALREADY INSTALLED, go to §0 and do not run §1–§7.** They create things that
+exist, and §3 in particular would overwrite an overlay carrying the repo's whole personality.
+
+## 0. Already installed? Upgrade instead
+
+⚠️ **THIS FILE INSTALLED AND NEVER RE-INSTALLED, AND THAT IS HOW A FLEET DRIFTS.** Every step
+below §0 is written for a fresh target. A session pointed at an installed repo had no instruction
+for the case it was actually in, so the consumer half of an upgrade was never stated anywhere and
+"upgrade" meant *bump the ref and hope*.
+
+**Detect the case first.** The target has `.github/workflows/claude.yml` calling this workflow.
+Read its `uses:` ref — that is the installed version. There is no second version number to invent:
+the pin *is* the signal.
+
+```bash
+grep -o 'team\.yml@[^ ]*' <target>/.github/workflows/claude.yml   # installed
+git ls-remote --tags https://github.com/matt-whitaker/claude-team  # available
+```
+
+Then, in order:
+
+1. **Read [`CHANGELOG.md`](CHANGELOG.md) from the installed ref to the current tag.** Every version
+   heading carries an `**Action required:**` line. If they all say `no`, steps 2 and 5 are the
+   whole upgrade.
+
+2. **Bump the `uses:` ref.** It is the only pin a consumer holds — `TEAM_REF` lives inside the
+   workflow and moves with the tag, so a consumer never edits it and must never be told to.
+   ⚠️ A repo that deliberately tracks `@mainline` skips this; see the release note in `CLAUDE.md`
+   for which ones and why.
+
+3. **Reconcile the stub — do not recreate it.** Diff it against
+   [`templates/consumer-stub.yml`](templates/consumer-stub.yml). Everything but the header comment,
+   the `uses:` ref and the `with:` values should be identical, so the diff is a real check rather
+   than noise. **New inputs appear here and nowhere else**: a consumer's stub is frozen, so a new
+   input never arrives on its own — it shows up as a line present in the template and absent in the
+   target.
+
+4. **Leave the overlays alone unless the CHANGELOG says otherwise.** They are the repo's
+   personality and this file has no business rewriting them.
+   ⚠️ **The exception that has already bitten: a base-prompt rule that an overlay now contradicts.**
+   An overlay composes *after* the base, so it **wins** — which means a base change tightening what
+   a role may do reaches nothing if the overlay still grants it. When an entry says a role's scope
+   narrowed, grep the overlays for the old grant.
+
+5. **Re-run everything the pin cannot carry — unconditionally, every time.** It is idempotent and
+   cheap, and this is the half a version number can never express:
+   - **§4's label loop.** ⚠️ Labels live in GitHub, not in the clone, so no ref bump has ever
+     touched them. It is the one step already written to be idempotent and it still drifted,
+     because nothing told anyone to re-run it.
+   - **The board** — is `project_number` still the board this repo's work goes on?
+   - **§6's settings and secrets** — has the CHANGELOG added a required one? *Allow GitHub Actions
+     to create and approve pull requests* is the one that fails late and looks like an engine bug.
+
+6. **Drill again (§7) only if something structural moved** — a new input, a routing change, a
+   changed role set. A pure prose release does not earn a run.
+
+⚠️ **Ship it the same way as an install: branch → PR → merge.** Never push the target's default
+branch, and remember nothing takes effect until merge, because `issues` events always run the
+workflow from the default branch.
+
 ## 1. Decide the four inputs
 
 Settle these before touching files; each is a judgment call about the target, not boilerplate.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -347,6 +347,102 @@ class TheRuntimesResolverActuallyRuns(unittest.TestCase):
                 self.assertIn("::error::", r.stdout + r.stderr)
 
 
+class TheReturningConsumerHasAPath(unittest.TestCase):
+    """⚠️ #39: ONBOARDING INSTALLED AND NEVER RE-INSTALLED. Every step was written for a fresh
+    target — §2 creates the stub, §3 creates overlays, §7 is a first-run drill — so a session
+    pointed at an installed repo had no instruction for the case it was actually in, and the
+    consumer half of an upgrade was never stated anywhere. "Upgrade" meant bump the ref and hope.
+
+    ⚠️ The version signal already existed: the `vN` tags and the `@ref` in every consumer's stub.
+    What was missing is what a bump *requires*, and what a bump can never carry."""
+
+    ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+    # ⚠️ READ IN setUp, NOT THE CLASS BODY. The other classes here read at module scope, which is
+    # fine for files that have always existed — but a class-body read of a file this change is
+    # INTRODUCING raises at import time, which takes the whole module down and hides every
+    # unrelated test in it. Caught by running these against mainline: the intended assertion
+    # failure arrived as `unittest.loader._FailedTest` with 40-odd other tests silently gone.
+    def setUp(self):
+        missing = [f for f in ("ONBOARDING.md", "CHANGELOG.md", "CLAUDE.md")
+                   if not (self.ROOT / f).exists()]
+        self.assertFalse(missing, f"required file(s) absent: {missing}")
+        self.ONBOARDING = (self.ROOT / "ONBOARDING.md").read_text()
+        self.CHANGELOG = (self.ROOT / "CHANGELOG.md").read_text()
+        self.CLAUDEMD = (self.ROOT / "CLAUDE.md").read_text()
+
+    def test_the_upgrade_path_comes_before_the_install_steps(self):
+        """⚠️ A returning reader must not have to read §1-§7 to discover they are in the wrong
+        place — §3 would overwrite an overlay carrying the repo's whole personality."""
+        upgrade = self.ONBOARDING.index("## 0. Already installed?")
+        first_install_step = self.ONBOARDING.index("## 1. Decide the four inputs")
+        self.assertLess(upgrade, first_install_step)
+
+    def test_the_install_steps_are_signposted_as_not_for_a_returning_reader(self):
+        self.assertRegex(self.ONBOARDING, r"ALREADY INSTALLED.*§0")
+
+    def test_the_case_is_detected_from_the_pin_not_a_new_number(self):
+        """⚠️ Copying claude-code's revision integer would be wrong: it needed one because its
+        install target is a session's knowledge and nothing else numbered it. Here the pin already
+        is the version, and a second number beside it invents a fact that exists."""
+        self.assertIn("the pin *is* the signal", self.ONBOARDING)
+        self.assertIn("git ls-remote --tags", self.ONBOARDING)
+
+    def test_the_consumer_is_never_told_to_edit_TEAM_REF(self):
+        """It lives inside the workflow and moves with the tag. A consumer holds exactly one pin."""
+        section = self.ONBOARDING[
+            self.ONBOARDING.index("## 0."):self.ONBOARDING.index("## 1.")]
+        self.assertIn("only pin a consumer holds", section)
+
+    def test_the_pin_cannot_carry_labels_and_the_path_says_so(self):
+        """⚠️ THE HALF NO VERSION NUMBER REACHES. Labels live in GitHub, not the clone, so no ref
+        bump has ever touched them — and the one step already written to be idempotent is the one
+        that drifted, because nothing told anyone to re-run it."""
+        section = self.ONBOARDING[
+            self.ONBOARDING.index("## 0."):self.ONBOARDING.index("## 1.")]
+        self.assertIn("unconditionally", section)
+        for carried in ("label", "board", "settings"):
+            with self.subTest(item=carried):
+                self.assertIn(carried, section.lower())
+
+    def test_the_overlay_wins_over_a_tightened_base_rule(self):
+        """⚠️ Measured, not hypothetical: the Writer's scope was narrowed in the base and two
+        consumer overlays went on granting what had just been removed."""
+        section = self.ONBOARDING[
+            self.ONBOARDING.index("## 0."):self.ONBOARDING.index("## 1.")]
+        self.assertIn("composes *after* the base", section)
+
+    def test_every_changelog_version_states_whether_to_act(self):
+        """⚠️ THE ONLY QUESTION A CONSUMER HAS. A list of merged PRs cannot answer it, so the
+        marker is asserted rather than trusted to habit — `no` is the commonest answer and the
+        most valuable one."""
+        headings = [m for m in re.finditer(r"^## (.+)$", self.CHANGELOG, re.M)]
+        self.assertTrue(headings, "the changelog has no version headings")
+        for i, head in enumerate(headings):
+            end = headings[i + 1].start() if i + 1 < len(headings) else len(self.CHANGELOG)
+            body = self.CHANGELOG[head.end():end]
+            with self.subTest(version=head.group(1)):
+                self.assertRegex(
+                    body, r"\*\*Action required:\*\* (yes|no|n/a|unknown)",
+                    f"{head.group(1)} does not say whether a consumer must act")
+
+    def test_there_is_always_somewhere_to_write_the_next_entry(self):
+        """⚠️ The entry is written in the PR that CAUSES it. Reconstructing consumer impact from a
+        merge log is the work this file exists to remove, and it is done worst by whoever is trying
+        to cut a tag."""
+        self.assertIn("## Unreleased", self.CHANGELOG)
+
+    def test_the_changelog_says_what_it_is_not(self):
+        self.assertIn("not a merge log", self.CHANGELOG)
+
+    def test_the_release_procedure_renames_the_unreleased_heading(self):
+        """⚠️ A changelog nobody is told to roll over accumulates one permanent Unreleased section
+        and stops distinguishing versions — which is the whole mechanism §0 reads."""
+        release = self.CLAUDEMD[self.CLAUDEMD.index("**Releasing**"):][:600]
+        self.assertIn("Unreleased", release)
+        self.assertIn("CHANGELOG.md", release)
+
+
 class ReleasePins(unittest.TestCase):
     """Every pin that must move together at release time, asserted equal on every push.
 


### PR DESCRIPTION
**Worked as-is** — `ONBOARDING.md` §0, a new `CHANGELOG.md`, the release procedure, and tests.

Closes #39

## The gap

`ONBOARDING.md` installed and never re-installed. Every step was written for a fresh target — §2
creates the stub, §3 creates overlays, §7 is a first-run drill. A session pointed at an
already-installed repo had no instruction for the case it was actually in, so the consumer half of
an upgrade was never stated anywhere and **"upgrade" meant bump the ref and hope**.

§0 sits **ahead of** the numbered steps, and the top of the file signposts it. A returning reader
must not have to read §1–§7 to discover they are in the wrong place: §3 would overwrite an overlay
carrying the repo's whole personality.

## No new version number

The signal already exists — the `vN` tags and the `@ref` in every consumer's stub. §0 detects the
case by reading that ref.

⚠️ Copying `claude-code#48`'s revision integer would have been wrong, and the issue says why: that
package needed one because its install target is a *session's knowledge*, which nothing else
numbered. Here **the pin is the version**, and a second number beside it invents a fact that
exists.

§0 also never tells a consumer to touch `TEAM_REF` — it lives inside the workflow and moves with
the tag. A consumer holds exactly one pin. A test asserts that.

## The open question, settled: a file

The issue left this genuinely open — `CHANGELOG.md` versus the tag's GitHub release notes. Three
reasons for the file, and the third decides it:

1. A session doing an upgrade is already in the clone.
2. A release note needs a network call and an API that can drop mid-session.
3. **A file is testable.** That is this package's standard for anything load-bearing, and
   `python3 -m unittest` cannot assert anything about a release note.

## What makes the changelog worth having

⚠️ **Consumer-facing or worthless.** A list of merged PRs cannot answer the only question a
consumer has — *must I act?* So every version heading carries an explicit `**Action required:**`
line, and a test asserts it rather than trusting habit. **`no` is the commonest answer and the
most valuable one**: a release nobody has to act on should say so in a word.

⚠️ **Entries are written in the PR that causes them, not at release time.** Reconstructing
consumer impact from a merge log is exactly the work the file exists to remove, and it is done
worst by whoever is trying to cut a tag. `## Unreleased` stays permanently open, and the release
procedure in `CLAUDE.md` now renames it — a changelog nobody is told to roll over accumulates one
permanent Unreleased section and stops distinguishing versions.

⚠️ **`v1.1`'s entry says `unknown`.** 24 commits separate it from the next entry, and inferring
their impact after the fact is precisely the guesswork this replaces. A consumer crossing that
boundary is told to follow §0 in full rather than trust a summary written backwards.

## Two things a pin can never carry

§5 of the path re-runs both **unconditionally, every time** — they are idempotent and cheap.

**Labels live in GitHub, not in the clone**, so no ref bump has ever touched them. ⚠️ The one step
already written to be idempotent is the one that drifted, because nothing told anyone to re-run
it — this repo's own `story` and `task` sat identical at `0E8A16` with empty descriptions while
`templates/labels.json` said otherwise. The board and §6's Actions settings are the same shape.

**An overlay composes *after* the base and therefore wins**, so a base change narrowing what a role
may do reaches nothing while the overlay still grants it. ⚠️ Measured rather than hypothetical: the
Writer's scope was corrected in #55 and two consumer overlays went on granting exactly what had
been removed. §0 says to grep the overlays whenever an entry reports a narrowed scope, and the
Unreleased entry does report it.

## Tests

10 cases, all verified failing against `mainline`.

⚠️ One of them exists because of a defect in the first version of this suite: it read its files in
the **class body**, so a missing `CHANGELOG.md` raised at import, took the whole module down, and
turned ten intended assertion failures into a single `unittest.loader._FailedTest` with forty-odd
unrelated tests silently gone. Reading in `setUp` with an explicit existence check makes the
failure land where it belongs. The other classes in this file read at module scope, which is fine
for files that have always existed — it is a file a change *introduces* where it bites.

`python3 -m compileall -q hooks && python3 -m unittest discover -s tests` — **152 passed**.

## Note on the rollout

Fleet work is paused at your request. This is pre-release infrastructure: cutting `v2` without §0
means every consumer upgrades by guesswork, which is the thing the issue is about.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_