### PR TITLE
Stop three author prompts telling a task to open its own PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 - **The Architect prompt now names the as-is story** — a story left whole, carrying its own
   `Branch:` line and a `Role:` stamp. No consumer action; it is the shaping side of a path routing
   already supported. Expect fewer unnecessary Writer tasks on small stories.
+- **⚠️ Three base author prompts stopped contradicting the shared rule.** `implementor.md`,
+  `designer.md` and `tester.md` still described the removed per-task-PR model — *"cut your own
+  branch off the story's, and open your own PR into it"* — against `_shared.md`'s *"A TASK HAS NO
+  PR"*, inside the same composed prompt. **Check your overlays for the same wording**: an overlay
+  composes after the base and wins, so a role section restating the old model there is untouched by
+  this fix.
 - **The story task-order comment's caption was wrong** — it read *"authors, then tests, then
   docs"* under a table correctly sorted writer-first. No action; the sort itself was never wrong,
   only the sentence explaining it.

--- a/prompts/designer.md
+++ b/prompts/designer.md
@@ -6,12 +6,27 @@ You are reached either by the delegator routing a task stamped `Role: designer`,
 
 ## Where your work goes
 
-Your task's **Branch** line names its *story's* branch. You cut your own branch off it and
-merge back into it, so your work reaches the story's PR through your own.
+Your task's **Branch** line names its *story's* branch — never a branch of its own. That is
+where the work has to end up, and a hook is what puts it there.
 
-⚠️ **Cut your own branch off the story's, and open your own PR into it** — see _Your
-branch_ above. The story's PR is opened by a scripted hook when your task PR merges; that
-one is not yours to create or to finish.
+⚠️ **YOU ARE ALREADY ON THE RIGHT BRANCH, AND IT IS NOT THAT ONE.** The system that started you
+always cuts a branch; it has no way to put you straight onto the story branch. What you are on is
+a **staging area**: `work-completion.py` commits your changes there and lands them on the story
+branch after you stop. Edit there and leave the git alone.
+
+⚠️ **A TASK HAS NO PR, AND THIS SECTION USED TO SAY IT DID** — *"cut your own branch off the
+story's, and open your own PR into it"*. That was the removed per-task-PR model, and obeying it
+opens exactly the extra PRs the current one exists to prevent. One story is one review; a PR per
+task splits it across several places and makes the maintainer reassemble it.
+
+So: **edit, report, stop.** Do not cut a branch, do not push, do not open a PR, and do not read
+the absence of one as something gone wrong — before the story's last task completes, its absence
+is the design. The story's PR is opened by a hook, from the story's branch, and it is not yours to
+create or to finish.
+
+⚠️ **This does not narrow what you may repair.** Fixing the call sites your own primitive change
+breaks is still yours — it is the same commit, on the same branch, reaching the story the same
+way. What changed is only how the work travels, never its scope.
 
 ## What you own
 

--- a/prompts/implementor.md
+++ b/prompts/implementor.md
@@ -9,12 +9,28 @@ across. See _What you own_.
 
 ## Where your work goes
 
-Your task's **Branch** line names its *story's* branch. You cut your own branch off it and
-merge back into it, so your work reaches the story's PR through your own.
+Your task's **Branch** line names its *story's* branch — never a branch of its own. That is
+where the work has to end up, and a hook is what puts it there.
 
-⚠️ **Cut your own branch off the story's, and open your own PR into it** — see _Your
-branch_ above. The story's PR is opened by a scripted hook when your task PR merges; that
-one is not yours to create or to finish.
+⚠️ **YOU ARE ALREADY ON THE RIGHT BRANCH, AND IT IS NOT THAT ONE.** The system that started you
+always cuts a branch; it has no way to put you straight onto the story branch. What you are on is
+a **staging area**: `work-completion.py` commits your changes there and lands them on the story
+branch after you stop. Edit there and leave the git alone.
+
+⚠️ **A TASK HAS NO PR, AND THIS SECTION USED TO SAY IT DID** — *"cut your own branch off the
+story's, and open your own PR into it"*. That was the removed per-task-PR model, and obeying it
+opens exactly the extra PRs the current one exists to prevent. One story is one review; a PR per
+task splits it across several places and makes the maintainer reassemble it.
+
+So: **edit, report, stop.** Do not cut a branch, do not push, do not open a PR, and do not read
+the absence of one as something gone wrong — before the story's last task completes, its absence
+is the design. The story's PR is opened by a hook, from the story's branch, and it is not yours to
+create or to finish.
+
+⚠️ **The one git exception you DO hold is elsewhere**: keeping the story branch current when it
+is stale, and resolving a conflicted landing when the maintainer summons you. That is a licence to
+act on the *story's* branch when asked — not to route your own task's work through a branch of
+your own.
 
 ## What you own
 
@@ -44,7 +60,6 @@ already gets right.
 - ⚠️ **Render controls with the accessible name the spec gives them.** The spec's nouns are the
   selectors: *a button named "Complete Mash"* means a button whose accessible name is exactly
   that, because the Tester queries by it and converges on your work without reading it.
-- Push to the story branch.
 - End your comment with a **Handoff**: what is implemented, what is still open, decisions
   and gotchas discovered, a one-line-per-file map, and how to verify. Keep it a scannable
   status doc — a bloated handoff costs the turns it was meant to save. A **🔔 Maintainer**

--- a/prompts/tester.md
+++ b/prompts/tester.md
@@ -22,11 +22,27 @@ story branch, so a handoff written during the first task would have nowhere to g
 
 ## Where your work goes
 
-The same place the Implementor's did: the story's branch, named on the issue's **Branch**
-line. Your tests land in the story's PR beside the code they cover.
+Your task's **Branch** line names its *story's* branch — never a branch of its own. That is
+where the work has to end up, and a hook is what puts it there.
 
-⚠️ **Cut your own branch off the story's, and open your own PR into it** — see _Your
-branch_ in the shared rules. Your tests land on the story branch when that PR merges.
+⚠️ **YOU ARE ALREADY ON THE RIGHT BRANCH, AND IT IS NOT THAT ONE.** The system that started you
+always cuts a branch; it has no way to put you straight onto the story branch. What you are on is
+a **staging area**: `work-completion.py` commits your changes there and lands them on the story
+branch after you stop. Edit there and leave the git alone.
+
+⚠️ **A TASK HAS NO PR, AND THIS SECTION USED TO SAY IT DID** — *"cut your own branch off the
+story's, and open your own PR into it"*. That was the removed per-task-PR model, and obeying it
+opens exactly the extra PRs the current one exists to prevent. One story is one review; a PR per
+task splits it across several places and makes the maintainer reassemble it.
+
+So: **edit, report, stop.** Do not cut a branch, do not push, do not open a PR, and do not read
+the absence of one as something gone wrong — before the story's last task completes, its absence
+is the design. The story's PR is opened by a hook, from the story's branch, and it is not yours to
+create or to finish.
+
+⚠️ **Your tests land beside the code they cover, in the story's one PR** — which is the point of
+running last. A reviewer reads the feature and its coverage as a single diff, and a separate test
+PR is exactly what would take that away.
 
 ## Driving the app
 

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -244,5 +244,84 @@ class TheWriterDoesNotOwnTheAgentInstructions(unittest.TestCase):
                     self.assertNotIn(claim, text)
 
 
+class NoBasePromptTellsATaskToOpenAPR(unittest.TestCase):
+    """⚠️ #19: THREE ROLE PROMPTS STILL DESCRIBED THE REMOVED PER-TASK-PR MODEL, and contradicted
+    `_shared.md` inside the same composed prompt.
+
+    `_shared.md`: *"A TASK HAS NO PR. THERE IS EXACTLY ONE PR PER STORY, AND IT IS NOT YOURS TO
+    OPEN."* Against `tester.md`/`implementor.md`/`designer.md`: *"Cut your own branch off the
+    story's, and open your own PR into it."* A role obeying its own section over the shared one
+    opens exactly the extra PRs the current model removed — and which instruction wins is the
+    model's call, which is the failure this package keeps paying for.
+
+    ⚠️ #19 ASKED WHETHER "THE BASE PROMPTS AGREE WITH EACH OTHER" IS ASSERTABLE WITHOUT BECOMING
+    BRITTLE, and the answer is no in general and yes here. Agreement over prose is a semantic
+    question no test can hold, and one that tried would need editing on every prompt change. A
+    single NAMED RULE is different: it is short, it is load-bearing, and it has now been
+    contradicted once per role. Assert the rule, not the agreement."""
+
+    AUTHORS = ("implementor", "designer", "tester", "writer")
+
+    def setUp(self):
+        self.root = pathlib.Path(__file__).resolve().parent.parent
+
+    def instructions(self, role):
+        """The prompt with its correction QUOTES removed.
+
+        ⚠️ This package's convention is that a corrected paragraph quotes what it replaced —
+        *"cut your own branch off the story's…"* now appears inside the ⚠️ notice explaining why
+        it is wrong. A naive search for the old wording therefore matches the fix itself and
+        fails forever. Strip `*"…"*` spans first, so what remains is only what the prompt
+        actually instructs."""
+        import re as _re
+        text = (self.root / "prompts" / f"{role}.md").read_text()
+        return _re.sub(r'\*"[^"]*"\*', " [quoted] ", text, flags=_re.S)
+
+    def test_the_strip_actually_removes_the_quoted_correction(self):
+        """Guards the helper: if the regex stops matching, every assertion below passes only
+        because it is reading the correction notice as prose, and the real check is gone."""
+        stripped = self.instructions("implementor")
+        self.assertIn("[quoted]", stripped, "no correction quote was stripped — check the regex")
+        self.assertNotIn("open your own PR into it", stripped)
+
+    def test_no_author_is_told_to_open_its_own_pr(self):
+        for role in self.AUTHORS:
+            text = self.instructions(role)
+            for banned in ("open your own PR", "your task PR", "your own PR into it"):
+                with self.subTest(role=role, phrase=banned):
+                    self.assertNotIn(banned, text)
+
+    def test_no_author_is_told_to_cut_its_own_branch(self):
+        for role in self.AUTHORS:
+            text = self.instructions(role)
+            for banned in ("Cut your own branch", "cut your own branch off",
+                           "merge back into it"):
+                with self.subTest(role=role, phrase=banned):
+                    self.assertNotIn(banned, text)
+
+    def test_the_shared_rule_still_says_what_the_roles_now_agree_with(self):
+        """⚠️ The assertions above are only meaningful while `_shared.md` still carries the rule.
+        If it were softened, they would pass over three prompts agreeing with nothing."""
+        shared = (self.root / "prompts/_shared.md").read_text()
+        self.assertIn("A TASK HAS NO PR", shared)
+        self.assertIn("IT IS NOT YOURS TO OPEN", shared)
+
+    def test_the_three_corrected_prompts_say_what_to_do_instead(self):
+        """A removed instruction with nothing in its place is how a role invents one."""
+        for role in ("implementor", "designer", "tester"):
+            with self.subTest(role=role):
+                text = (self.root / "prompts" / f"{role}.md").read_text()
+                self.assertIn("staging area", text)
+                self.assertIn("edit, report, stop", text.lower())
+
+    def test_the_implementors_git_licence_survives_and_is_bounded(self):
+        """⚠️ It is the one author that may act on the story branch — keeping it current, and
+        resolving a conflicted landing when summoned. Removing the per-task-PR language must not
+        remove that, and must not be read as restoring a branch of its own."""
+        text = (self.root / "prompts/implementor.md").read_text()
+        self.assertIn("keeping the story branch current", text)
+        self.assertNotIn("- Push to the story branch.", text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Worked as-is** — three prompt sections, one stale bullet, a changelog entry, and tests.

Closes #19

## The contradiction

Inside the **same composed prompt**:

| file | says |
|---|---|
| `prompts/_shared.md` | *"A TASK HAS NO PR. THERE IS EXACTLY ONE PR PER STORY, AND IT IS NOT YOURS TO OPEN."* |
| `implementor.md` · `designer.md` · `tester.md` | *"Cut your own branch off the story's, and open your own PR into it."* |

A role obeying its own section over the shared one opens exactly the extra PRs the current model
removed — and **which instruction wins is the model's call**. That is the third contradiction of
this shape found in the package, after the Architect's `Sequencing` worked example (#28) and its
Writer-versus-don't-split rules (#47).

`work-completion.py` lands a task's commits on the story branch and the story's PR opens when the
last task completes, so the shared prompt was current and these three were stale.

## The rewrites

Each in its own role's voice, keeping the ⚠️ convention. The shared substance: the Branch line
names the *story's* branch, the branch you are on is a **staging area** a hook lands from, and the
instruction is **edit, report, stop**.

Each also keeps what its own role would otherwise lose in the edit:

- **Implementor** — its licence to act on the story branch is *elsewhere* (keeping it current,
  resolving a conflicted landing when summoned). Bounded explicitly so removing the per-task-PR
  language is not read as restoring a branch of its own.
- **Designer** — repairing the call sites its own primitive change breaks is unchanged. What
  changed is how the work travels, never its scope.
- **Tester** — its tests land beside the code they cover in the story's one PR, which is the point
  of running last. A separate test PR is exactly what would take that away.

Also removes `implementor.md`'s stale **"Push to the story branch"** bullet under *Before you
finish* — it told an author to do the one git operation `work-completion.py` owns.

## The question #19 asked

> Nothing in the suite asserts that the base prompts agree with each other, which is why this
> survived. Whether that is assertable without becoming brittle is a judgement call — say so
> either way.

**Not in general, yes for this.** Agreement over prose is a semantic question no test can hold, and
one attempting it would need editing on every prompt change — which is the brittleness the issue
was worried about, and it is real.

A single **named rule** is a different object: short, load-bearing, and now contradicted once per
role. So the tests assert *the rule*, not the agreement — no author prompt tells a task to open a
PR or cut a branch, and `_shared.md` still carries the rule they now agree with. That last one
matters: without it the other assertions would pass over three prompts agreeing with nothing.

## ⚠️ A trap this repo sets for its own tests

The convention here is that a corrected paragraph **quotes what it replaced** — so
*"cut your own branch off the story's…"* now appears inside the ⚠️ notice explaining why it is
wrong. A naive search for the old wording matches **the fix itself** and fails forever.

The helper strips `*"…"*` spans before asserting, and a guard test checks the strip actually
fires. Without that guard, every other assertion in the class would pass while quietly reading the
correction notice as prose.

Verified against `mainline`: **20 failures** across the class, 0 here.

## Consumers

The changelog entry flags that an **overlay composes after the base and wins**, so a role section
restating the old model in a consumer's `.claude-team/prompts/` is untouched by this. Same shape as
the Writer scope correction in #55.

`python3 -m compileall -q hooks && python3 -m unittest discover -s tests` — **168 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_