### PR TITLE
Say which of the three cases an empty handoff is, and keep the evidence

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -1800,6 +1800,7 @@ jobs:
           LANDED_REF: ${{ steps.completion.outputs.landed_ref }}
         run: "$RUNNER_TEMP/agent-bin/finish-pr.py"
       - name: Persist the author's handoff
+        id: handoff
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1819,6 +1820,16 @@ jobs:
           # takes the one that produced output. Empty when neither ran or the step failed,
           # which the hook treats as "nothing to post" rather than an error.
           HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output || steps.tester.outputs.structured_output || steps.writer.outputs.structured_output }}
+          # ⚠️ ALL FOUR, AS PAIRS, because `||` cannot pick between outcomes the way it picks
+          # between outputs: a skipped step's outcome is the truthy string "skipped", so the
+          # chain would always take the first and name the wrong step. This is what lets the
+          # hook tell "no author ran" from "its step failed" from "it ran, succeeded, and
+          # returned nothing" — the third being the one that silently halts a story (#32).
+          OUTCOMES: >-
+            implementor=${{ steps.implementor.outcome }}
+            designer=${{ steps.designer.outcome }}
+            tester=${{ steps.tester.outcome }}
+            writer=${{ steps.writer.outcome }}
         run: "$RUNNER_TEMP/agent-bin/post-handoff.py"
       - name: Update the story's task order
         if: always()
@@ -1840,12 +1851,21 @@ jobs:
       # `always()` so a FAILED run still yields its transcript, which is when you most want one.
       # ⚠️ Turned on and off at runtime by the AGENT_TRANSCRIPTS repository variable; unset means
       # off, so this is inert until someone opts in. See .github/actions/capture-transcript.
+      #
+      # ⚠️ ONE CASE OVERRIDES THE TOGGLE, and it is the case that most needs the file: a role
+      # step that SUCCEEDED and returned no handoff. That silently halts a story, and WHY it
+      # produced nothing is unknowable from anything else the run keeps — the transcript is the
+      # only artifact that can say whether the model emitted nothing, emitted something the
+      # schema rejected, or emitted it where the action did not read. Measured on the run that
+      # produced #32, `AGENT_TRANSCRIPTS` was unset, so the channel-with-no-reader failure landed
+      # on exactly the run that needed it. Mirrors the action's own upstream-error diagnosis,
+      # which is ungated for the same stated reason.
       - name: Capture the transcript
         if: always()
         continue-on-error: true
         uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
         with:
-          enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'authors') }}
+          enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'authors') || steps.handoff.outputs.evidence == 'true' }}
           role: ${{ needs.delegate.outputs.roles }}
           execution_file: ${{ steps.implementor.outputs.execution_file || steps.designer.outputs.execution_file || steps.tester.outputs.execution_file || steps.writer.outputs.execution_file }}
           role_arn: ${{ secrets.AWS_TRANSCRIPTS_ROLE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 - **The Architect prompt now names the as-is story** — a story left whole, carrying its own
   `Branch:` line and a `Role:` stamp. No consumer action; it is the shaping side of a path routing
   already supported. Expect fewer unnecessary Writer tasks on small stories.
+- **⚠️ A role step that succeeds but returns no handoff now FAILS the run.** It used to print
+  *"no author ran, or its step failed"* — both halves false in that case — and report success while
+  the task stayed open and the story halted. No action, but **expect a previously-green failure
+  mode to start showing red**: that is the run telling you a task did not close. Re-trigger it.
+  The transcript is also captured for that one case regardless of `AGENT_TRANSCRIPTS`, because why
+  the step produced nothing is unknowable from anything else the run keeps.
 - **⚠️ Three base author prompts stopped contradicting the shared rule.** `implementor.md`,
   `designer.md` and `tester.md` still described the removed per-task-PR model — *"cut your own
   branch off the story's, and open your own PR into it"* — against `_shared.md`'s *"A TASK HAS NO

--- a/hooks/post-handoff.py
+++ b/hooks/post-handoff.py
@@ -25,13 +25,68 @@ ISSUE = os.environ.get("ISSUE", "")
 PR = os.environ.get("PR", "")
 STORY = os.environ.get("STORY", "")
 ROLES = os.environ.get("ROLES", "").strip()
+# ⚠️ `role=outcome` pairs for all four author steps, because `||` cannot pick between them here.
+# A skipped step's outcome is the truthy string "skipped", so the `||` chain used for
+# `structured_output` would always take the first one and report the wrong step's fate.
+OUTCOMES = os.environ.get("OUTCOMES", "")
 
 if not team.REPO:
     team.fail("REPO is required")
 
+
+def _outcome(role: str) -> str:
+    for pair in OUTCOMES.split():
+        name, _, value = pair.partition("=")
+        if name == role:
+            return value
+    return ""
+
+
+def _note(key: str, value: str) -> None:
+    """A step output for the caller — used to ungate transcript capture."""
+    path = os.environ.get("GITHUB_OUTPUT")
+    if path:
+        with open(path, "a") as fh:
+            fh.write(f"{key}={value}\n")
+
+
+# ⚠️ THREE CASES, AND THIS USED TO PRINT ONE SENTENCE THAT WAS FALSE IN THE WORST OF THEM.
+# It said "no author ran, or its step failed" — and the case that actually halts a story is the
+# third: an author RAN, its step SUCCEEDED, and it returned nothing usable. Both halves of that
+# sentence are false there, so the one line a reader got sent them looking for a skipped job or a
+# red step, neither of which existed (#32). Measured on a consumer at v1.1: the tester step ran
+# 2m27s and completed, `HANDOFF` was empty, every `closed`-gated step skipped, and the task sat
+# open until a human closed it fourteen hours later — at which point nothing could open the
+# story's PR at all (#31).
 if not HANDOFF:
-    print("No handoff to post — no author ran, or its step failed.")
-    raise SystemExit(0)
+    ran = [r for r in ROLES.split() if _outcome(r) not in ("", "skipped")]
+    if not ran:
+        print("No handoff to post — no author ran.")
+        raise SystemExit(0)
+
+    failed = [r for r in ran if _outcome(r) != "success"]
+    if failed:
+        print(
+            "No handoff to post — "
+            + ", ".join(f"the {r} step {_outcome(r)}" for r in failed)
+            + ". The red step above is the signal; this is not a separate fault."
+        )
+        raise SystemExit(0)
+
+    # ⚠️ THE ONE THAT HALTS A STORY, AND IT REPORTED SUCCESS FOR AS LONG AS IT EXISTED. No task
+    # closes, every `closed`-gated step skips, and nothing anywhere says why — so this is an
+    # error, not a line. ⚠️ Keep the evidence too: `evidence=true` ungates transcript capture in
+    # the caller, because WHY the step produced nothing is unknowable from anything else the run
+    # keeps, and this is exactly the run that needed it.
+    _note("evidence", "true")
+    team.fail(
+        "The "
+        + ", ".join(ran)
+        + " step ran and SUCCEEDED but returned no handoff, so this task will not close and the "
+        "story is halted. Nothing failed upstream — the model emitted no structured output, or "
+        "emitted something the schema rejected. Re-trigger the task; if it recurs, the captured "
+        "transcript is the only artifact that can say which."
+    )
 
 # ⚠️ A PR FOLLOW-UP MUST REACH THE STORY, and for a long time it did not. This read
 # `if not ISSUE: exit` — and the workflow blanks ISSUE on a PR trigger — so the hook returned

--- a/tests/test_post_handoff.py
+++ b/tests/test_post_handoff.py
@@ -1,0 +1,110 @@
+import unittest
+from harness import HookCase
+
+STORY = {"600": {"body": "Branch: `600-thing`"}}
+HANDOFF = '{"commitMessage":"do it","remaining":[],"decisions":[],' \
+          '"testingNotes":[],"docsCandidates":[]}'
+
+ALL_SKIPPED = "implementor=skipped designer=skipped tester=skipped writer=skipped"
+TESTER_RAN = "implementor=skipped designer=skipped tester=success writer=skipped"
+TESTER_DIED = "implementor=skipped designer=skipped tester=failure writer=skipped"
+
+
+class TheEmptyHandoffSaysWhichCaseItIs(HookCase):
+    """⚠️ #32: ONE SENTENCE, FALSE IN THE CASE THAT ACTUALLY HALTS A STORY.
+
+    It printed *"No handoff to post — no author ran, or its step failed."* Both halves are false
+    when an author RAN and SUCCEEDED and returned nothing usable — so the one line a reader got
+    sent them looking for a skipped job or a red step, neither of which existed. Measured on a
+    consumer at v1.1: the tester step ran 2m27s and completed, HANDOFF was empty, every
+    `closed`-gated step skipped, and the task sat open until a human closed it fourteen hours
+    later — at which point nothing could open the story's PR at all (#31)."""
+
+    def post(self, **env):
+        return self.run_hook("post-handoff.py", {
+            "GH_TOKEN": "ghs_fixturetoken", "STORY": "600", "ISSUE": "601",
+            "STUB_ISSUES": STORY, **env,
+        })
+
+    # ── case 1: nobody ran ────────────────────────────────────────────────
+    def test_no_author_ran_is_quiet_and_says_only_that(self):
+        r = self.post(HANDOFF="", ROLES="", OUTCOMES=ALL_SKIPPED)
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("no author ran", r.stdout)
+        self.assertNotIn("::error::", r.stdout + r.stderr)
+
+    def test_a_role_routed_but_never_started_counts_as_nobody_ran(self):
+        """ROLES names who *should* run; the outcome says whether it did. A skipped step is not
+        a role that ran, and treating it as one would report the wrong case."""
+        r = self.post(HANDOFF="", ROLES="tester", OUTCOMES=ALL_SKIPPED)
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("no author ran", r.stdout)
+
+    # ── case 2: it ran and died ───────────────────────────────────────────
+    def test_a_failed_step_is_named_and_not_double_reported(self):
+        """The red step above is already the signal — reddening this one too would report one
+        fault twice, which this package has paid for before."""
+        r = self.post(HANDOFF="", ROLES="tester", OUTCOMES=TESTER_DIED)
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("the tester step failure", r.stdout)
+        self.assertNotIn("::error::", r.stdout + r.stderr)
+
+    # ── case 3: it ran, succeeded, returned nothing ───────────────────────
+    def test_a_successful_step_with_no_handoff_is_an_error(self):
+        """⚠️ The task will not close and the story is halted. A plain line in a green run is
+        how that stayed invisible."""
+        r = self.post(HANDOFF="", ROLES="tester", OUTCOMES=TESTER_RAN)
+
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("::error::", r.stdout + r.stderr)
+
+    def test_it_names_the_role_and_contradicts_neither_half_of_the_old_sentence(self):
+        r = self.post(HANDOFF="", ROLES="tester", OUTCOMES=TESTER_RAN)
+        out = r.stdout + r.stderr
+
+        self.assertIn("tester", out)
+        self.assertIn("SUCCEEDED", out)
+        self.assertIn("Nothing failed upstream", out)
+        self.assertNotIn("no author ran, or its step failed", out)
+
+    def test_it_says_what_will_happen_and_what_to_do(self):
+        r = self.post(HANDOFF="", ROLES="tester", OUTCOMES=TESTER_RAN)
+        out = r.stdout + r.stderr
+
+        self.assertIn("will not close", out)
+        self.assertIn("Re-trigger", out)
+
+    def test_it_ungates_transcript_capture(self):
+        """⚠️ WHY the step produced nothing is unknowable from anything else the run keeps, and
+        on the run that produced #32 the toggle was off — the channel-with-no-reader failure
+        landing on exactly the run that needed it. The caller ORs this into `enabled`."""
+        r = self.post(HANDOFF="", ROLES="tester", OUTCOMES=TESTER_RAN)
+
+        self.assertEqual(r.outputs.get("evidence"), "true")
+
+    def test_the_other_two_cases_do_not_ungate_it(self):
+        """Capture stays off where the toggle says off — a failed step already has its own
+        ungated diagnosis, and a run where nothing started has nothing to capture."""
+        for label, roles, outcomes in (
+            ("nobody ran", "", ALL_SKIPPED),
+            ("step failed", "tester", TESTER_DIED),
+        ):
+            with self.subTest(case=label):
+                r = self.post(HANDOFF="", ROLES=roles, OUTCOMES=outcomes)
+                self.assertNotIn("evidence", r.outputs)
+
+    # ── the happy path is untouched ───────────────────────────────────────
+    def test_a_real_handoff_still_posts_and_reddens_nothing(self):
+        r = self.post(HANDOFF=HANDOFF, ROLES="tester", OUTCOMES=TESTER_RAN)
+
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertTrue([c for c in r.calls if c["kind"] == "upsert_comment"],
+                        f"the handoff was not posted; calls={r.calls}")
+        self.assertNotIn("evidence", r.outputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -443,6 +443,34 @@ class TheReturningConsumerHasAPath(unittest.TestCase):
         self.assertIn("CHANGELOG.md", release)
 
 
+class TheEmptyHandoffKeepsItsEvidence(unittest.TestCase):
+    """⚠️ #32, second half. A role step that succeeds and returns no handoff silently halts a
+    story, and WHY it produced nothing is unknowable from anything else the run keeps. On the run
+    that produced the issue, `AGENT_TRANSCRIPTS` was unset — so the channel-with-no-reader failure
+    landed on exactly the run that needed it."""
+
+    def test_the_handoff_step_is_addressable(self):
+        """Guards the two assertions below: without the id, `steps.handoff.outputs` resolves to
+        nothing and the override silently never fires."""
+        self.assertIn("id: handoff", TEAM)
+
+    def test_a_successful_step_with_no_handoff_overrides_the_toggle(self):
+        self.assertIn("steps.handoff.outputs.evidence == 'true'", TEAM)
+
+    def test_the_toggle_still_governs_every_other_case(self):
+        """The override is an OR, not a replacement — an ordinary run stays inert until someone
+        opts in, which is what keeps transcripts off a public console by default."""
+        self.assertIn("contains(vars.AGENT_TRANSCRIPTS, 'authors')", TEAM)
+
+    def test_all_four_author_outcomes_reach_the_hook(self):
+        """⚠️ Pairs, not a `||` chain. A skipped step's outcome is the truthy string "skipped",
+        so the chain used for `structured_output` would always take the first and name the wrong
+        step's fate — which is the misreport this whole issue is about."""
+        for role in ("implementor", "designer", "tester", "writer"):
+            with self.subTest(role=role):
+                self.assertIn(f"{role}=${{{{ steps.{role}.outcome }}}}", TEAM)
+
+
 class ReleasePins(unittest.TestCase):
     """Every pin that must move together at release time, asserted equal on every push.
 


### PR DESCRIPTION
**Worked as-is** — one hook, the workflow wiring, a changelog entry, and thirteen tests.

Closes #32

## The sentence

`post-handoff.py` printed exactly one line when `HANDOFF` was empty:

> `No handoff to post — no author ran, or its step failed.`

⚠️ **Both halves are false in the case that actually halts a story.** An author *did* run and its
step did *not* fail — it succeeded and returned nothing usable. The one line a reader got sent
them looking for a skipped job or a red step, neither of which existed, and the third possibility
was the one that happened and the one the message did not offer.

Measured on a consumer at `v1.1`: the tester step ran **2m27s** and completed, the diagnosis
printed *"no upstream failure recorded for tester"*, `HANDOFF` was empty in both `finish-pr.py` and
`post-handoff.py`, and all three `closed`-gated steps skipped. The task sat open until a human
closed it **fourteen hours later** — at which point nothing could open the story's PR at all (#31).
The run reported success throughout.

## The discriminator was half-present

The hook already read `ROLES` at line 27 and never reached it. What was missing is **whether the
step succeeded**, so the workflow now passes all four author outcomes.

⚠️ **As `role=outcome` pairs, not a `||` chain.** A skipped step's outcome is the truthy string
`"skipped"`, so the chain used for `structured_output` would always take the first and name the
wrong step's fate — the same class of misreport this issue is about.

## Three cases, one of them loud

| case | report |
|---|---|
| nobody ran | plain line |
| a step failed | named, plain line |
| **ran, succeeded, empty** | **`::error::` — the run goes red** |

The middle one stays quiet deliberately: **the red step above is already the signal**, and
reporting one fault twice is a habit this package has paid for (#44's two error lines for one
fault, where the louder one was the false one).

The third is loud because the task will not close, the story is halted, and nothing else says so.

## Keeping the evidence

That case also **ungates transcript capture**, whatever `AGENT_TRANSCRIPTS` says.

Why the step produced nothing is unknowable from anything else the run keeps — the transcript is
the only artifact that can say whether the model emitted no structured output, emitted something
the schema rejected, or emitted it where the action did not read. ⚠️ On the run that produced this
issue the variable was unset, so **the channel-with-no-reader failure landed on exactly the run
that needed it.** This mirrors the action's own upstream-error diagnosis, which is ungated for the
same stated reason.

The override is an **OR**, not a replacement: an ordinary run stays inert until someone opts in,
which is what keeps transcripts off a public console by default.

## Tests

Thirteen, all verified failing against `mainline`.

Nine hook cases cover all three branches, both the ungating and its absence, and the happy path.
Four workflow cases pin the wiring — including an **id-is-present guard**, without which
`steps.handoff.outputs` resolves to nothing and the override silently never fires.

⚠️ Worth noting: **`test_every_env_var_a_hook_reads_is_set_somewhere` also failed against mainline**
— the general dead-channel test added in #45 caught `OUTCOMES` being read and never set, on a
change made two weeks after it. That is the test doing exactly what it was written for.

`python3 -m compileall -q hooks && python3 -m unittest discover -s tests` — **181 passed**.

## For consumers

The changelog entry flags the one thing worth knowing: **a previously-green failure mode will
start showing red.** That is the run telling you a task did not close, and the action is to
re-trigger it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_