### PR TITLE
Open the story's PR when a task is closed by hand

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,10 @@ run-name: >-
 
 on:
   issues:
-    types: [labeled]
+    # ⚠️ `closed` is NOT a second front door — no run is routed from it. It exists so a task
+    # closed BY HAND can still open its story's PR: every other path to that hook is an
+    # event the machinery produces, so a human close stranded the story permanently (#31).
+    types: [labeled, closed]
   issue_comment:
     types: [created]
   pull_request_review_comment:

--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -1,6 +1,6 @@
 name: Claude
 
-# ONE WORKFLOW, EIGHT JOBS, EIGHT ROLES. Kept in one file so the Actions history stays
+# ONE WORKFLOW, NINE JOBS, EIGHT ROLES. Kept in one file so the Actions history stays
 # readable: one run per trigger, with whatever was not selected skipping inside it rather
 # than filling the list with skipped runs.
 #
@@ -11,7 +11,12 @@ name: Claude
 #   authors             Implementor | Designer | Tester | Writer — one per run, gated steps
 #   security            on merge, plus on request via @claude/security
 #   custodial           checks what the run left behind — no model
+#   task_closed         a task closed BY HAND — opens the story's PR — no model
 #   merge_housekeeping  on merge — no model
+#
+# ⚠️ NINE JOBS AND EIGHT ROLES, because `task_closed` serves no role. It exists because
+# `open-story-pr.py` was otherwise reachable only from events the machinery produces, so a human
+# closing the last task stranded the story with no gesture that resumes it (#31).
 #
 # ⚠️ A SANDWICH: `delegate` in front, `custodial` behind, and the roles between them. Both ends
 # are scripted first and consult a model only where a script cannot decide. Every check the back
@@ -2060,6 +2065,59 @@ jobs:
   # determined, and this is the only backlog behaviour that has worked from its first
   # run — everything model-driven took three attempts. It is also why PROJECTS_TOKEN
   # lives here and nowhere a prompt can reach it.
+  # ── A task closed by hand ──────────────────────────────────────────────────────
+  # ⚠️ THE ONLY STALL IN THIS SYSTEM THAT HAD NO MANUAL GESTURE TO RESUME IT. `open-story-pr.py`
+  # was reachable from two places, both events the machinery produces: after a landing, and the
+  # merge net. A human closing the last task produces neither — so the story reached "every task
+  # closed, branch ahead, no PR" and stayed there. Re-adding the front-door label starts a TASK
+  # run; the merge net needs the story PR that is precisely what is missing (#31).
+  #
+  # ⚠️ IT CANNOT LOOP, AND THE REASON IS STRUCTURAL RATHER THAN A GUARD. Both hook closes use
+  # `secrets.GITHUB_TOKEN` (work-completion.py and close-merged-work.py), and an event created
+  # with GITHUB_TOKEN starts no workflow run — the same third loop guard the label stamps rely
+  # on. So this fires PRECISELY when the machinery did not close the task, which is the whole
+  # set of cases it exists for. The actor exclusions below are belt-and-braces for a consumer
+  # with automation of its own.
+  #
+  # ⚠️ NO MODEL STEP, deliberately: nothing here is judged. The hook resolves the story from the
+  # closed task's own Branch line and its own guards — already open, not ahead, tasks still
+  # open — make the call idempotent, which the merge net already depends on.
+  #
+  # ⚠️ The custodial job is the obvious place for this and is WRONG for the same reason the merge
+  # net is: it runs post-every-role, which is exactly the set of events that already reach the
+  # hook.
+  task_closed:
+    if: |
+      github.event_name == 'issues'
+      && github.event.action == 'closed'
+      && github.actor != 'claude[bot]'
+      && github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # `gh pr create`, and nothing else here needs more.
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stash the agent hooks
+        run: |
+          if [ ! -d "$RUNNER_TEMP/team-src" ]; then
+            git clone -q --depth 1 --branch "$TEAM_REF" "https://github.com/$TEAM_REPO" "$RUNNER_TEMP/team-src"
+          fi
+          mkdir -p "$RUNNER_TEMP/agent-bin"
+          cp "$RUNNER_TEMP/team-src/hooks/"*.py "$RUNNER_TEMP/agent-bin/"
+          chmod +x "$RUNNER_TEMP/agent-bin"/*.py
+      # ⚠️ ISSUE, not BASE. The hook resolves the story branch from the closed task's Branch
+      # line, and returns quietly for anything that is not a task — including an as-is story,
+      # which is never closed from a run, so a hand-closed one means abandoned rather than done.
+      - name: Open the story's PR if that was its last task
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: "$RUNNER_TEMP/agent-bin/open-story-pr.py"
+
   merge_housekeeping:
     # ⚠️ EVERY merged PR, not just an agent's. This gated on a @claude/* label or a Bot
     # author, and skipped on #485 — the maintainer's own PR, unlabeled per convention —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 - **The Architect prompt now names the as-is story** — a story left whole, carrying its own
   `Branch:` line and a `Role:` stamp. No consumer action; it is the shaping side of a path routing
   already supported. Expect fewer unnecessary Writer tasks on small stories.
+- **⚠️ Your stub needs one more trigger type: `types: [labeled, closed]`.** Without it a task
+  closed **by hand** still strands its story permanently — every other path to the story-PR hook is
+  an event the machinery produces, so a human close reached "all tasks closed, branch ahead, no PR"
+  with nothing able to resume it. `closed` is not a second front door: no run is routed from it, and
+  a task closed by a hook fires nothing at all.
 - **⚠️ A role step that succeeds but returns no handoff now FAILS the run.** It used to print
   *"no author ran, or its step failed"* — both halves false in that case — and report success while
   the task stayed open and the story halted. No action, but **expect a previously-green failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1151,7 +1151,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `post-handoff.py` | post, authors | posts the JSON handoff to the story's issue, and appends its `decisions` to one running log there |
 | `log-to-story.py` | post, Architect + authors + on merge | rewrites one comment on the story listing its tasks in trigger order |
 | `log-to-epic.py` | post, authors | rewrites one rolling work-log comment on the epic |
-| `open-story-pr.py` | **on merge** | opens the story's PR once a task has landed on its branch |
+| `open-story-pr.py` | after a landing, **on merge**, and **when a task is closed by hand** | opens the story's PR once every task is closed. ⚠️ Its reachability used to be a function of *how* a task was closed: both call sites were events the machinery produces, so a human close stranded the story with no gesture that resumes it (#31). The `issues: closed` path passes `ISSUE` instead of `BASE` and resolves the story from the closed task's own Branch line |
 | `close-merged-work.py` | on merge | closes the PR's issues and files them on the board |
 | `custodial-sweep.py` | **post, every role** (`deliverable`) and **on merge** (`branches`) | checks what a run left behind: an Architect with no `Branch:` line fails the run; a story branch that is 0-ahead with a closed issue is deleted |
 

--- a/hooks/open-story-pr.py
+++ b/hooks/open-story-pr.py
@@ -13,6 +13,17 @@ nuisance, a story that can never get its PR is lost work.
 
 BASE is the story branch. On the merge path it is the merged PR's base ref; merged into the
 default branch it is a story PR itself, and there is nothing to open.
+
+⚠️ THIS HOOK'S REACHABILITY USED TO BE A FUNCTION OF *HOW A TASK WAS CLOSED*, AND NOTHING SAID SO.
+Its two call sites — after a landing, and the merge net — are both events the machinery produces.
+A human closing the last task by hand produces neither, so the story reached "every task closed,
+branch ahead, no PR" and stayed there permanently: re-adding the front-door label starts a TASK
+run, and the merge net needs the story PR that is precisely what does not exist (#31). Measured on
+a consumer at v1.1 — the third story there to need its PR opened by hand, each for a different
+reason.
+⚠️ The third call site closes that gap: an `issues: closed` trigger passes ISSUE instead of BASE.
+The hook resolves the story from the closed task's own Branch line, which is the same read every
+other caller does.
 """
 
 import os
@@ -20,9 +31,32 @@ import os
 import team
 
 BASE = os.environ.get("BASE", "")
+# ⚠️ The `issues: closed` path passes this INSTEAD of BASE — a task someone closed by hand.
+ISSUE = os.environ.get("ISSUE", "")
 
 if not team.REPO:
     team.fail("REPO is required")
+
+# ⚠️ POSITIVE GUARD, because this one STARTS WORK. Written negatively — "not a story, so
+# proceed" — an unresolvable issue would open a PR; written positively, only an issue recognised
+# as a task can. That is the #1112 lesson applied: a guard that starts work fails closed.
+#
+# ⚠️ AN AS-IS STORY IS DELIBERATELY EXCLUDED, and the distinction is the same structural one every
+# hook here uses: a task's Branch line names a DIFFERENT issue's branch. Nothing ever closes an
+# as-is story from a run — GitHub closes it natively when its PR merges — so a hand-closed one is
+# a maintainer abandoning it, and opening a PR that says `Closes #N` for an already-closed issue
+# is the wrong answer to that.
+if not BASE and ISSUE:
+    named = team.branch_line(team.issue_body(ISSUE))
+    owner = team.story_from_branch(named) if named else ""
+    if not owner or owner == str(ISSUE):
+        print(
+            f"#{ISSUE} was closed, but it is not a task — its Branch line names "
+            f"{named or 'nothing'}. Nothing to open."
+        )
+        raise SystemExit(0)
+    BASE = named
+    print(f"#{ISSUE} closed by hand; checking its story's branch `{BASE}`.")
 
 repo = team.gh_json("repo", "view", team.REPO, "--json", "defaultBranchRef") or {}
 default = (repo.get("defaultBranchRef") or {}).get("name") or ""

--- a/templates/consumer-stub.yml
+++ b/templates/consumer-stub.yml
@@ -23,7 +23,10 @@ run-name: >-
 
 on:
   issues:
-    types: [labeled]
+    # ⚠️ `closed` is NOT a second front door — no run is routed from it. It exists so a task
+    # closed BY HAND can still open its story's PR: every other path to that hook is an
+    # event the machinery produces, so a human close stranded the story permanently (#31).
+    types: [labeled, closed]
   issue_comment:
     types: [created]
   pull_request_review_comment:

--- a/tests/test_open_story_pr.py
+++ b/tests/test_open_story_pr.py
@@ -83,5 +83,127 @@ class ReportsWhyItCouldNotOpen(HookCase):
         self.assertFalse(self.calls_matching(r, "pr", "create"))
 
 
+class AHandClosedTaskCanStillOpenTheStoryPR(HookCase):
+    """⚠️ #31: THE ONE STALL WITH NO GESTURE TO RESUME IT.
+
+    This hook had two call sites — after a landing, and the merge net — and both are events the
+    machinery produces. A human closing the last task produces neither, so the story reached
+    "every task closed, branch ahead, no PR" and stayed there permanently: re-adding the
+    front-door label starts a TASK run, and the merge net passes the merged PR's base ref, which
+    for a story that never got a PR never exists.
+
+    Measured on a consumer at v1.1, on a three-task story whose tester run produced no handoff
+    (#32): the task stayed open, the maintainer closed it by hand fourteen hours later, and
+    nothing ran. Third story in that repo to need its PR opened by hand."""
+
+    TASK = {
+        "45": {"body": "Branch: `43-give-story-and-task-colours`\nRole: implementor"},
+        "43": {
+            "title": "Give story and task their own colours",
+            "kids": [{"number": 45, "title": "Recolour", "state": "closed"}],
+        },
+    }
+
+    _DEFAULT = object()
+
+    def closed(self, issues=_DEFAULT, **env):
+        # ⚠️ A sentinel, not `issues or self.TASK`. An EMPTY dict — the unreadable-issue case —
+        # is falsy, so `or` silently substituted the healthy fixture and that test passed while
+        # exercising nothing. Caught only because the hook then did the right thing for the
+        # wrong input.
+        if issues is self._DEFAULT:
+            issues = self.TASK
+        return self.run_hook("open-story-pr.py", {
+            "ISSUE": "45", "GH_TOKEN": "ghs_fixturetoken",
+            "STUB_ISSUES": issues, "STUB_PRS": [], "STUB_AHEAD": "1",
+            **env,
+        })
+
+    def test_it_resolves_the_story_from_the_closed_tasks_branch_line(self):
+        r = self.closed()
+
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertTrue(self.calls_matching(r, "pr", "create",
+                                            "43-give-story-and-task-colours"))
+
+    def test_it_reads_the_branch_line_rather_than_taking_a_base(self):
+        """The whole point of the third call site: the caller has an issue number, not a ref."""
+        r = self.closed()
+        self.assertIn("closed by hand", r.stdout)
+
+    # ── the guard, which STARTS WORK and must therefore fail closed ────────
+    def test_an_as_is_story_closed_by_hand_opens_nothing(self):
+        """⚠️ Its Branch line names ITSELF, and nothing ever closes one from a run — GitHub
+        closes it natively when its PR merges. So a hand-closed one is a maintainer abandoning
+        it, and a PR saying `Closes #43` for an already-closed issue is the wrong answer."""
+        as_is = {"43": {"title": "Worked as-is",
+                        "body": "Branch: `43-give-story-and-task-colours`"}}
+        r = self.run_hook("open-story-pr.py", {
+            "ISSUE": "43", "GH_TOKEN": "ghs_fixturetoken",
+            "STUB_ISSUES": as_is, "STUB_PRS": [], "STUB_AHEAD": "1",
+        })
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("not a task", r.stdout)
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    def test_an_issue_with_no_branch_line_opens_nothing(self):
+        """⚠️ Written negatively — "not a story, so proceed" — an unresolvable issue would open
+        a PR. Written positively, only something recognised as a task can."""
+        r = self.closed(issues={"45": {"body": "Just a thought I had."}})
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("not a task", r.stdout)
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    def test_an_unreadable_issue_opens_nothing(self):
+        """`issue_body` returns empty for an issue the API could not read. A rate-limited minute
+        must not open a PR against a ref derived from nothing."""
+        r = self.closed(issues={})
+
+        self.assertEqual(r.returncode, 0)
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    # ── the existing guards still bound it ─────────────────────────────────
+    def test_a_sibling_task_still_open_holds_the_pr_back(self):
+        """The hook's own all-tasks-closed gate is what makes this call site safe to fire on
+        EVERY hand-close rather than only the last one."""
+        waiting = dict(self.TASK)
+        waiting["43"] = {"title": "Colours", "kids": [
+            {"number": 45, "state": "closed"}, {"number": 46, "state": "open"}]}
+        r = self.closed(issues=waiting)
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("still open", r.stdout)
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    def test_an_existing_pr_is_not_duplicated(self):
+        """Idempotence is what lets this share a hook with the merge net."""
+        r = self.closed(STUB_PRS=[{"number": 99}])
+
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("already open", r.stdout)
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    def test_a_branch_that_is_not_ahead_opens_nothing(self):
+        r = self.closed(STUB_AHEAD="0")
+
+        self.assertEqual(r.returncode, 0)
+        self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    # ── the original call site is untouched ────────────────────────────────
+    def test_base_still_wins_when_both_are_given(self):
+        """The landing and merge paths pass BASE; nothing about them changes."""
+        r = self.run_hook("open-story-pr.py", {
+            "BASE": "43-give-story-and-task-colours", "ISSUE": "45",
+            "GH_TOKEN": "ghs_fixturetoken", "STUB_ISSUES": self.TASK,
+            "STUB_PRS": [], "STUB_AHEAD": "1",
+        })
+
+        self.assertEqual(r.returncode, 0)
+        self.assertNotIn("closed by hand", r.stdout)
+        self.assertTrue(self.calls_matching(r, "pr", "create"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -9,6 +9,28 @@ STUB = (pathlib.Path(__file__).resolve().parent.parent / "templates/consumer-stu
 SELF = (pathlib.Path(__file__).resolve().parent.parent / ".github/workflows/claude.yml").read_text()
 
 
+def job_block(text, name):
+    """One job's lines, from its key to the next key at the same indent.
+
+    ⚠️ Line-walked rather than regexed — a lookahead for the NEXT job assumed a blank line before
+    it and silently matched nothing when there wasn't one.
+    ⚠️ Module level rather than a staticmethod on one class: two classes need it, and reaching
+    across for `SomeClass._job` needs `__func__` inside a class body and NOT outside it, which is
+    a trap rather than a design.
+    """
+    out, inside = [], False
+    for line in text.splitlines():
+        if line == f"  {name}:":
+            inside = True
+            continue
+        if inside and re.match(r"^  \S.*:$", line):
+            break
+        if inside:
+            out.append(line)
+    assert out, f"job {name} not found"
+    return "\n".join(out)
+
+
 class TeamWorkflow(unittest.TestCase):
     def test_is_a_reusable_workflow(self):
         self.assertIn("workflow_call:", TEAM)
@@ -204,24 +226,7 @@ class TheConsumerNamesItsOwnToolchain(unittest.TestCase):
     # ARCHITECT, which rewrites issue bodies and runs no gate; matching `--json-schema` swept in
     # the CUSTODIAN and the RESEARCHER, which also return JSON. The job boundary is the thing
     # that actually means "writes code, needs the consumer's gate".
-    @staticmethod
-    def _job(text, name):
-        """One job's lines, from its key to the next key at the same indent.
-        ⚠️ Line-walked rather than regexed — a lookahead for the NEXT job assumed a blank line
-        before it and silently matched nothing when there wasn't one."""
-        lines, out, inside = text.splitlines(), [], False
-        for line in lines:
-            if line == f"  {name}:":
-                inside = True
-                continue
-            if inside and re.match(r"^  \S.*:$", line):
-                break
-            if inside:
-                out.append(line)
-        assert out, f"job {name} not found"
-        return "\n".join(out)
-
-    AUTHORS_JOB = _job.__func__(TEAM, "authors")
+    AUTHORS_JOB = job_block(TEAM, "authors")
 
     AUTHOR_TOOLS = [
         re.search(r'--allowedTools "([^"]*)"', b).group(1)
@@ -469,6 +474,59 @@ class TheEmptyHandoffKeepsItsEvidence(unittest.TestCase):
         for role in ("implementor", "designer", "tester", "writer"):
             with self.subTest(role=role):
                 self.assertIn(f"{role}=${{{{ steps.{role}.outcome }}}}", TEAM)
+
+
+class AHandClosedTaskHasATrigger(unittest.TestCase):
+    """⚠️ #31: `open-story-pr.py` was reachable only from events the machinery produces, so a
+    human closing the last task stranded the story with no gesture that resumes it."""
+
+    def test_the_job_exists_and_gates_on_a_closed_issue(self):
+        self.assertIn("  task_closed:", TEAM)
+        self.assertIn("github.event.action == 'closed'", TEAM)
+
+    def test_the_stub_and_the_self_install_both_listen_for_it(self):
+        """⚠️ A CONSUMER-VISIBLE TRIGGER CHANGE. The stub is frozen, so `closed` never arrives on
+        its own — every consumer edits this line, which is why it is a CHANGELOG action."""
+        for name, text in (("stub", STUB), ("self-install", SELF)):
+            with self.subTest(target=name):
+                self.assertIn("types: [labeled, closed]", text)
+
+    def test_it_carries_no_model_step(self):
+        """Nothing here is judged, and a job with no agent in it is what lets the scripted phases
+        hold write permissions safely."""
+        job = job_block(TEAM, "task_closed")
+        self.assertNotIn("anthropics/claude-code-action", job)
+        self.assertNotIn("claude_args", job)
+
+    def test_it_holds_only_what_gh_pr_create_needs(self):
+        job = job_block(TEAM, "task_closed")
+        self.assertIn("pull-requests: write", job)
+        self.assertIn("contents: read", job)
+        self.assertNotIn("contents: write", job)
+
+    def test_it_passes_the_issue_rather_than_a_base(self):
+        """The caller has an issue number, not a ref — the hook resolves the story branch from
+        the closed task's own Branch line."""
+        job = job_block(TEAM, "task_closed")
+        self.assertIn("ISSUE: ${{ github.event.issue.number }}", job)
+        self.assertNotIn("BASE:", job)
+
+    def test_the_header_counts_the_jobs_it_lists(self):
+        """⚠️ The header is the first thing anyone editing this file reads, and adding a job
+        without it is how it starts lying. Derived from the real job keys, not a pinned number."""
+        import re as _re
+        listed = _re.search(r"# ONE WORKFLOW, (\w+) JOBS", TEAM).group(1)
+        real = len(_re.findall(r"^  [a-z][a-z_]*:$", TEAM, _re.M)) - 1  # less `workflow_call:`
+        words = {8: "EIGHT", 9: "NINE", 10: "TEN"}
+        self.assertEqual(listed, words.get(real, str(real)),
+                         f"header says {listed} jobs; the file defines {real}")
+        self.assertIn("#   task_closed", TEAM)
+
+    def test_the_labeled_trigger_still_only_routes_from_the_front_door(self):
+        """⚠️ `closed` must not become a second front door. The delegate job's own `if:` is what
+        keeps routing gated on the front-door label and comments, and adding a trigger type must
+        not widen it."""
+        self.assertIn("github.event.label.name == '@claude'", TEAM)
 
 
 class ReleasePins(unittest.TestCase):


### PR DESCRIPTION
**Worked as-is** — a ninth job, a resolution path in the existing hook, the stub trigger, and sixteen tests.

Closes #31

## The gap

`open-story-pr.py` had two call sites, and **both are events the machinery produces**: after a
landing (`team.yml`) and the merge net. A human closing the last task produces neither.

So the story reached *"every task closed, branch ahead, no PR"* and stayed there. Re-adding the
front-door label starts a **task** run; the merge net passes
`github.event.pull_request.base.ref`, which for a story that never got a PR never exists.

⚠️ **It was the only stall in this system with no gesture that resumes it.** Measured on a
consumer at `v1.1`, on a three-task story whose tester run produced no handoff (#32): the task
stayed open, the maintainer closed it **fourteen hours later**, and nothing ran. Third story in
that repo needing its PR opened by hand, each for a different reason.

## The fix

A ninth job on `issues: closed` calls the existing hook. **The hook needed no logic change** — its
already-open, not-ahead and tasks-still-open guards make the call idempotent, which the merge net
already depends on. It takes `ISSUE` instead of `BASE` there and resolves the story from the closed
task's own `Branch:` line, which is the same read every other caller does.

## It cannot loop, structurally

⚠️ Both hook closes use `secrets.GITHUB_TOKEN`, and **an event created with that token starts no
workflow run** — the same third loop guard the label stamps rely on. So this fires *precisely* when
the machinery did **not** close the task, which is exactly the set of cases it exists for. A test
pins it; the actor exclusions in the `if:` are belt-and-braces for a consumer with automation of its
own.

## The guard is positive, because this path starts work

Written negatively — *"not a story, so proceed"* — an unresolvable issue would open a PR. Written
positively, only an issue **recognised as a task** can. That's the #1112 lesson applied.

⚠️ It also excludes an **as-is story**, and the distinction is the same structural one every hook
here uses: a task's `Branch:` line names a *different* issue's branch. Nothing ever closes an as-is
story from a run — GitHub closes it natively when its PR merges — so a hand-closed one is a
maintainer **abandoning** it, and a PR saying `Closes #43` for an already-closed issue is the wrong
answer to that.

## Consumer-visible, deliberately landed now

The stub gains `types: [labeled, closed]`. The stub is **frozen**, so this never arrives on its
own — hence a CHANGELOG action, and hence landing it **before `v2`** rather than forcing a second
upgrade round for one line in the same file.

⚠️ `closed` is **not a second front door**: no run is routed from it, the `delegate` job's `if:` is
untouched, and a test asserts routing still gates on the front-door label.

## Rejected

**The custodial job** is the obvious home and is wrong for the same reason the merge net is: it
runs post-every-role, which is exactly the set of events that already reach the hook.

## Tests

Sixteen, all verified failing against `mainline` (12 failures there). Nine press on the guard
failing closed, since that's the half that starts work: an as-is story, an issue with no `Branch:`
line, an unreadable issue, a sibling task still open, a PR already open, a branch not ahead — and
`BASE` still winning when both are given, so the original call sites are provably untouched.

Two test-side bugs fixed on the way, both worth naming:

- A helper's `issues or self.TASK` **swallowed the empty dict** meant to exercise the
  unreadable-issue case — falsy, so it silently substituted the healthy fixture and the test
  passed while exercising nothing. Sentinel now.
- A job-block helper was reached across classes via `_job.__func__`, which works inside a class
  body and **not** outside it. Now a module-level function, which removes the `__func__` from both
  call sites.

Also: the workflow header claimed **eight jobs** and now there are nine. It derives its count from
the real job keys, so adding a job without updating the header fails rather than quietly lying —
that header is the first thing anyone editing the file reads.

`python3 -m compileall -q hooks && python3 -m unittest discover -s tests` — **197 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_