### PR TITLE
Stop discarding a finished run for exceeding its turn cap

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -114,6 +114,25 @@ name: Claude
 # and secret masking covers logs only — not an API payload a model could write — so it
 # stays out of any environment a prompt can read. Step env is per-step, which is what makes
 # these two safe: the model step in the same job cannot see it.
+# ⚠️ `--max-turns` IS A DISCARD THRESHOLD, NOT A BUDGET, AND RAISING IT COSTS NOTHING.
+# Nothing enforces it: runs of 95 and 99 turns against a cap of 80 are on record, and the action
+# then FAILS a result the model had already completed — throwing finished, committed work away
+# after it was paid for (#1). The numbers sit far above any observed run so a completed result is
+# never discarded. `timeout-minutes` on the job is the ceiling that actually binds, which is why
+# every model job carries one; without it a hung call burns the 6-hour default.
+#
+# ⚠️ A CEILING IS NOT FREE, so it is 4x the longest healthy run rather than close to it. Timing a
+# job out kills its POST-hooks too — the landing, the handoff, the findings — so a ceiling tight
+# enough to cut a slow-but-working run destroys exactly what that run produced. Asserted.
+#
+# ⚠️ ONE NUMBER FOR EVERY MODEL JOB, because ~15 minutes is the only healthy-run figure this
+# package has actually measured, and it was measured on `authors` — the longest role. A per-job
+# ceiling would be nine guesses dressed as precision. Measure a role, then tighten its own.
+#
+# ⚠️ A RUN THAT STOPS AT EXACTLY 10 TURNS means the cap has begun binding through the SDK path
+# instead (claude-code-action#1177, which reports `maxTurns` defaulting to 10 when unwired). Both
+# halves above change meaning at once if that happens, so treat it as a signal, not a flake.
+#
 # ⚠️ TRIGGERS, run-name AND concurrency LIVE IN THE CONSUMER'S STUB — a reusable workflow's own
 # run-name is ignored and its workflow-level concurrency is unsupported; see templates/.
 on:
@@ -180,6 +199,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       # write so the unroutable path can leave a comment rather than skipping silently
@@ -326,6 +346,11 @@ jobs:
           prompt: ${{ steps.route-prompt.outputs.body }}
           # Reads the issue and answers. No Write/Edit: it must not "helpfully" add the missing
           # `Role:` stamp — a route that rewrote its own input would leave nothing to notice.
+          # ⚠️ THE ONE CAP LEFT LOW, AND IT IS CONTAINMENT RATHER THAN A BUDGET. Every other role's
+          # result is a deliverable, so discarding it loses the run; this step is
+          # `continue-on-error` with a documented fallback, so a discarded answer degrades to the
+          # script's own route with its notice intact. A routing call needing 15 turns has already
+          # failed at the thing it was asked to do.
           claude_args: |
             --model sonnet
             --allowedTools "Read,Glob,Grep,Bash(gh:*)"
@@ -504,6 +529,7 @@ jobs:
         || (!github.event.issue.pull_request && contains(github.event.comment.body, '@claude/architect'))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       # write purely to push the epic's (empty) integration branch — the prompt
       # forbids committing to it; this role writes no code
@@ -584,7 +610,7 @@ jobs:
           claude_args: |
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(gh:*),Bash(git:*)"
-            --max-turns 100
+            --max-turns 150
 
       # ⚠️ FIRST of the post-hooks, and the reason branch creation is no longer the model's.
       # The action mints its branch LOCALLY and never pushes one with no commits — and an
@@ -711,6 +737,7 @@ jobs:
       always() && needs.delegate.result != 'skipped'
       && contains(needs.delegate.outputs.roles, 'claude')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       # reads to answer, writes only its own reply. No branch, no code.
       contents: write
@@ -821,7 +848,7 @@ jobs:
             --model sonnet
             --allowedTools "Read,Glob,Grep,Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh label list:*),Bash(git:*)"
             --json-schema '${{ steps.repairs-schema.outputs.body }}'
-            --max-turns 40
+            --max-turns 150
 
       # ⚠️ THE MODEL PROPOSES, THIS DISPOSES. Deterministic at both ends, the same shape as
       # post-handoff/post-findings: the schema forces the report, this forces delivery — and here
@@ -874,6 +901,7 @@ jobs:
         || (!github.event.issue.pull_request && contains(github.event.comment.body, '@claude/researcher'))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       # ⚠️ contents READ, unlike every authoring role and unlike the Architect. A spike ships
       # nothing and has no branch to cut.
@@ -1013,7 +1041,7 @@ jobs:
             --model sonnet
             --allowedTools "Read,WebSearch,WebFetch"
             --json-schema '${{ steps.findings-schema.outputs.body }}'
-            --max-turns 80
+            --max-turns 150
 
       # ⚠️ THE ONLY WAY THE FINDINGS REACH ANYONE. The role has no shell, so it cannot run `gh`
       # and cannot write its own results anywhere. Deterministic at both ends, the same shape as
@@ -1314,7 +1342,7 @@ jobs:
       # authors need is the consumer's `.claude-team/setup.sh`.
       - name: Consumer setup
         if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'designer') || contains(steps.roles.outputs.list, 'tester') || contains(steps.roles.outputs.list, 'writer')
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: |
           if [ -x .claude-team/setup.sh ]; then
             .claude-team/setup.sh
@@ -1435,7 +1463,7 @@ jobs:
           claude_args: |
             --model opus
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*)${{ steps.runtimes.outputs.grants }}"
-            --max-turns 80
+            --max-turns 150
             --json-schema '${{ steps.schema.outputs.body }}'
 
       # ── Designer ──
@@ -1508,7 +1536,7 @@ jobs:
           claude_args: |
             --model opus
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*)${{ steps.runtimes.outputs.grants }}"
-            --max-turns 80
+            --max-turns 150
             --json-schema '${{ steps.schema.outputs.body }}'
 
       # ── Tester ──
@@ -1585,7 +1613,7 @@ jobs:
           claude_args: |
             --model sonnet
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*)${{ steps.runtimes.outputs.grants }}"
-            --max-turns 80
+            --max-turns 150
             --json-schema '${{ steps.schema.outputs.body }}'
 
       # ── Writer ──
@@ -1675,7 +1703,7 @@ jobs:
           claude_args: |
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*)${{ steps.runtimes.outputs.grants }}"
-            --max-turns 80
+            --max-turns 150
             --json-schema '${{ steps.schema.outputs.body }}'
 
       # ── Once, for the job ──
@@ -1901,6 +1929,7 @@ jobs:
            ))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       # ⚠️ write, not read: the on-demand path's whole contract is that a requested review
@@ -1981,7 +2010,7 @@ jobs:
           claude_args: |
             --model sonnet
             --allowedTools "Read,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue create:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh repo view:*),Bash(gh project item-add:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git status:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git blame:*),Bash(npm audit:*)"
-            --max-turns 40
+            --max-turns 150
 
       # ⚠️ Diagnostics only, and it must never redden a good run — hence continue-on-error, and
       # `always()` so a FAILED run still yields its transcript, which is when you most want one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,18 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 - **Story PRs and landings report their failures.** `open-story-pr.py` now says what `gh` refused
   and names the two usual causes; `finish-pr.py` no longer reports landed work as stranded. No
   action — but if you have been opening story PRs by hand, the next failure will tell you why.
+- **⚠️ A finished run is no longer thrown away for exceeding its turn cap.** `--max-turns` bounds
+  nothing — runs of 95 and 99 turns against a cap of 80 are on record — so the only thing it did
+  was fail a result the model had already completed, discarding committed work after it was paid
+  for. Every deliverable-producing role now sits at 150. No action, and **no extra spend**: the
+  number was never a budget. Expect work that used to arrive via a `failure/*` capture branch to
+  land normally instead.
+- **⚠️ Every model job now carries a 60-minute `timeout-minutes` ceiling**, where five of six
+  previously had none and ran under GitHub's six-hour default. This is the limit that actually
+  binds now that the turn cap does not. No action, but **a job that hangs is now cut at an hour
+  rather than at six** — and if a role in your repo legitimately runs longer than an hour, say so
+  before upgrading, because a timed-out job loses its post-hooks and with them whatever it
+  produced.
 
 ## v1.1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1114,6 +1114,22 @@ An issue that removes a role's permission to stop converts a cheap, informative 
 expensive, opaque one — measured across five runs on one story, where the first three reported
 precisely what blocked them in 1–4 minutes and the last two ground to the cap with nothing.
 
+⚠️ [E20] **"THE CAP" IN THE PARAGRAPHS ABOVE IS A DISCARD THRESHOLD, NOT A BUDGET.** Nothing
+enforces `--max-turns`: runs of 95 and 99 turns against a cap of 80 are on record. What the number
+does is fail a result the model had already **completed**, throwing away finished, committed work
+after it was paid for — so the check reached the deliverable and never the spend. Every
+deliverable-producing role now sits at 150, far above any observed run; raising it costs nothing,
+because it was bounding nothing.
+⚠️ **`timeout-minutes` on the job is the ceiling that actually binds**, and five of the six model
+jobs carried none — so the real ceiling was GitHub's six-hour default while the visible number said
+80. Every model job carries one now, asserted in the suite.
+⚠️ **`route` keeps its low cap of 15, and that is containment rather than a budget.** Its step is
+`continue-on-error` with a documented fallback to the script's own route, so a discarded answer
+degrades rather than losing the run — the one place where throwing a result away is cheap.
+⚠️ **A run that stops at exactly 10 turns is the signal to re-read all of this**: it means the cap
+has begun binding through the SDK path instead (`claude-code-action#1177`), and both halves change
+meaning at once.
+
 ⚠️ [E15] **AND THE THIRD SHAPE IS GATHERING WITHOUT PRODUCING, which neither of the other two catches.**
 Stopping early is a plan with unticked boxes; stopping late is grinding on one obstacle. This is
 neither: every turn succeeds, every turn yields something genuinely new, and the deliverable is

--- a/RULES.md
+++ b/RULES.md
@@ -393,6 +393,30 @@ one.
 
 > Evidence: the front/back split for `branch-navigation.py` is gone; it is one hook at every site.
 
+### E20 — A limit checked after the cost cannot prevent it. It can only destroy the result.
+
+`--max-turns 80` reads as a budget and bounds nothing: runs of 95 and 99 turns are on record, and
+what the number actually does is fail a result the model had already **completed** — discarding
+finished, committed work after it was paid for. The spend happened either way; the only thing the
+check could still reach was the deliverable.
+
+⚠️ **Find the layer that actually binds before trusting a number.** Here it is `timeout-minutes`,
+which the platform enforces — and five of six model jobs had none, so the ceiling everyone assumed
+was 80 turns was in fact six hours. A control nobody has tested against its own limit is a claim,
+not a bound.
+
+⚠️ **The price, stated:** raising the threshold removes the only line that ever announced a long
+run. That is the correct trade, because the announcement arrived as a failure on work that had
+succeeded — but it means nothing now reports a run that goes long, and the ceiling is the only
+thing that will stop one.
+
+⚠️ **The wrong fix is deleting the flag.** Nothing would then be exceeded, and if the unwired-SDK
+path (`claude-code-action#1177`, reporting `maxTurns` defaulting to 10) ever becomes true for
+`claude_args`, every author run silently truncates at 10 turns instead.
+
+> Evidence: #1 · two incidents, 154 insertions recovered by hand from a capture branch ·
+> `TheTurnCapIsADiscardThresholdNotABudget` in `tests/test_workflow.py`.
+
 ---
 
 ## Rules for writing rules

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -672,3 +672,98 @@ class CanonicalLabels(unittest.TestCase):
             re.search(r"(?i)\bits own\b[^.]*\bPR\b", desc),
             "the task description claims a task has its own PR; the story level owns it")
 
+
+
+def claude_args_blocks(text):
+    """Every `claude_args: |` literal block, as its raw content lines.
+
+    ⚠️ Text-walked rather than parsed: the suite is stdlib only, and the trap being asserted is a
+    property of the RAW block anyway — a YAML parser would happily hand back the leaked comment as
+    a string and tell you nothing was wrong.
+    """
+    out, buf, indent = [], None, ""
+    for line in text.splitlines():
+        if buf is not None:
+            if not line.strip() or line.startswith(indent):
+                buf.append(line)
+                continue
+            out.append(buf)
+            buf = None
+        m = re.match(r"^(\s+)claude_args: \|\s*$", line)
+        if m:
+            indent = m.group(1) + " "
+            buf = []
+    if buf is not None:
+        out.append(buf)
+    assert out, "no claude_args blocks found"
+    return out
+
+
+def model_jobs(text):
+    """Jobs that call the host action — derived, never enumerated.
+
+    A list would go stale the first time a role is added, which is this package's own rule for
+    anything a hook or a test keys on.
+    """
+    names = [m.group(1) for m in re.finditer(r"^  ([a-z][a-z_]*):$", text, re.M)]
+    found = [n for n in names if "anthropics/claude-code-action" in job_block(text, n)]
+    assert found, "no model jobs found"
+    return found
+
+
+class TheTurnCapIsADiscardThresholdNotABudget(unittest.TestCase):
+    """⚠️ #1: NOTHING ENFORCES `--max-turns`. Runs of 95 and 99 turns against a cap of 80 are on
+    record, and the action then FAILS a result the model had already completed — discarding
+    finished, committed work after it was paid for. Raising the number costs nothing, because the
+    number was never bounding spend; it only decides whether a finished result is thrown away."""
+
+    OBSERVED = 99   # the highest turn count on record, brewdocs.beer#1159
+    HEALTHY = 15    # minutes; the longest healthy run observed, per the authors job
+
+    def test_every_deliverable_role_sits_above_the_observed_ceiling(self):
+        """A cap at or below a real run's turn count discards that run's work."""
+        checked = 0
+        for job in model_jobs(TEAM):
+            if job == "delegate":
+                continue  # containment, asserted separately below
+            for cap in re.findall(r"--max-turns (\d+)", job_block(TEAM, job)):
+                checked += 1
+                self.assertGreater(
+                    int(cap), self.OBSERVED,
+                    f"{job}'s cap of {cap} would discard a completed run of {self.OBSERVED} turns")
+        self.assertEqual(checked, 8, "expected 8 deliverable-producing caps")
+
+    def test_route_is_the_only_cap_left_low_and_says_why(self):
+        """⚠️ Its result is DESIGNED to be discardable — `continue-on-error` plus a documented
+        fallback to the script's own route — so a low threshold there is containment. Every other
+        role's result is the run's deliverable."""
+        low = [c for c in re.findall(r"--max-turns (\d+)", TEAM) if int(c) <= self.OBSERVED]
+        self.assertEqual(low, ["15"], "a second low cap appeared; it would discard finished work")
+        self.assertIn("THE ONE CAP LEFT LOW", TEAM)
+        self.assertIn("continue-on-error", job_block(TEAM, "delegate"))
+
+    def test_every_model_job_carries_the_ceiling_that_actually_binds(self):
+        """⚠️ With turns unenforced, `timeout-minutes` is the ONLY thing bounding a run. Five model
+        jobs had none, so the recommendation on #1 — "the ceiling that actually binds is
+        timeout-minutes on the job" — was true of `authors` and nothing else."""
+        for job in model_jobs(TEAM):
+            with self.subTest(job=job):
+                found = re.findall(r"^    timeout-minutes: (\d+)$", job_block(TEAM, job), re.M)
+                self.assertEqual(len(found), 1,
+                                 f"{job} has no job-level ceiling; it defaults to 360 minutes")
+                self.assertLess(int(found[0]), 360,
+                                f"{job}'s ceiling is no tighter than the default")
+                self.assertGreaterEqual(
+                    int(found[0]), 4 * self.HEALTHY,
+                    f"{job}'s ceiling is under 4x the longest healthy run; a cut job loses its "
+                    f"POST-hooks, and with them whatever the run produced")
+
+    def test_no_comment_leaks_into_a_claude_args_block(self):
+        """⚠️ `claude_args: |` IS A LITERAL BLOCK SCALAR, SO `#` IS CONTENT, NOT A COMMENT — the
+        line reaches the CLI as an argument, because the argument list is parsed line by line.
+        A comment about a flag belongs above the block, where `#` means what it looks like."""
+        for block in claude_args_blocks(TEAM):
+            for line in block:
+                self.assertFalse(
+                    line.lstrip().startswith("#"),
+                    f"a comment leaked into a claude_args block and becomes an argument: {line!r}")


### PR DESCRIPTION
Closes #1.

## The defect

`--max-turns` bounds nothing. Runs of **95 and 99 turns against a cap of 80** are on record, and what the number actually does is fail a result the model had already **completed** — throwing away finished, committed work after it was paid for. #1272's discarded run had produced 154 insertions across 10 files that passed lint, `tsc` and the build unmodified when recovered by hand from its capture branch.

The check reached the deliverable and never the spend.

## What changed

**Every deliverable-producing role goes to 150.** No extra cost, because the number was never a budget — it does not increase what a run spends, it stops the post-hoc check discarding what was already spent. This is the recommendation already written on #1.

**`route` keeps 15**, and that is containment rather than a budget. Its step is `continue-on-error` with a documented fallback to the script's own route, so a discarded answer degrades with its notice intact. It is the one place where throwing a result away is cheap.

**Every model job gains a 60-minute `timeout-minutes`.**

## The premise on #1 was false, and that is the part worth reading

> The real budget control is elsewhere: since nothing enforces turns, the ceiling that actually binds is `timeout-minutes` on the job.

Measured — that was true of `authors` and nothing else:

| job | ceiling before |
|---|---|
| `authors` | 60 min |
| `delegate`, `architect`, `claude`, `researcher`, `security` | **none — GitHub's 360-minute default** |

So the visible number said 80 turns and the real ceiling was six hours. Raising the caps without fixing that would have left the stated budget control absent on five of six model jobs.

**Why one number rather than per-job.** ~15 minutes is the only healthy-run figure this package has measured, and it was measured on `authors` — the longest role. 60 is 4× it. A per-job ceiling would be nine guesses dressed as precision; measure a role, then tighten its own.

**A ceiling is not free**, and the diff says so: timing a job out kills its post-hooks too — the landing, the handoff, the findings — so a ceiling tight enough to cut a slow-but-working run destroys exactly what that run produced. My first pass set 15/30/45 per job; the test I had just written rejected them, which is the outcome I wanted from it.

## Found while writing this

`claude_args: |` is a **literal block scalar**, so `#` is content, not a comment — the line reaches the CLI as an argument, because the argument list is parsed line by line. I wrote the route note inside the block, `yaml.safe_load` parsed it happily, and only reading back the parsed value showed the comment sitting in the argument list. Now asserted for every block.

## RULES.md — E20

> A limit checked after the cost cannot prevent it. It can only destroy the result.

Carries its price, per W7: raising the threshold removes the only line that ever announced a long run. That is the correct trade — the announcement arrived as a *failure on work that had succeeded* — but nothing reports a long run now, and the ceiling is the only thing that will stop one.

Names the wrong fix, per W2: deleting the flag. Nothing would then be exceeded, but if the unwired-SDK path (`claude-code-action#1177`, `maxTurns` defaulting to 10) ever becomes true for `claude_args`, every author run silently truncates at 10 turns. A run that stops at exactly 10 is the signal that both halves of this change have flipped meaning.

## Verification

- Gate: **208 tests, green** (was 204).
- All four new tests were run against unfixed `mainline` first: **7 failures**, each for the expected reason (`claude's cap of 40 would discard a completed run of 99 turns`; `delegate has no job-level ceiling; it defaults to 360 minutes`; …).
- The comment-leak test was proved by re-injecting the leak I had actually written.
- ⚠️ **Not verifiable before merge.** `issues` and `issue_comment` run the workflow from the default branch, so this branch's version never fires — the tests are the whole gate.

## Not in scope

- `custodial`, `task_closed` and `merge_housekeeping` still default to 360. They carry no model step, so the turn-cap argument does not reach them. Flagging rather than sweeping in.
- **#1's second acceptance box — caps observable/configurable per consumer — is not done**, and I think the box has changed shape: now that the cap is a discard threshold and the timeout is the budget, what is worth exposing is the *timeout*, not the cap. Filing that as its own issue rather than guessing at a mechanism I cannot test before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AM6dFNNqp7k3akUmJw1dbk)_