### PR TITLE
⚠️ DO NOT MERGE — v2 release commit, for tagging only

### DIFF
--- a/.github/actions/load-prompt/action.yml
+++ b/.github/actions/load-prompt/action.yml
@@ -34,7 +34,7 @@ inputs:
   ref:
     description: The ref of that repo to fetch
     required: false
-    default: mainline
+    default: v2
   overlay:
     description: The consumer's overlay directory
     required: false

--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -153,7 +153,7 @@ env:
   # the workflow fetches at run time. Release tooling must move both together — a drift check is
   # part of the release job, not optional.
   TEAM_REPO: matt-whitaker/claude-team
-  TEAM_REF: mainline
+  TEAM_REF: v2
 
 jobs:
   # ── Delegate ───────────────────────────────────────────────────────────────────
@@ -279,7 +279,7 @@ jobs:
           echo "routing schema loaded (${#body} chars)"
       - id: route-prompt
         if: steps.route.outputs.defaulted == 'true' || steps.route.outputs.consult == 'true'
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: route
       - id: custodian
@@ -478,7 +478,7 @@ jobs:
       - name: Capture the routing transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'route') }}
           role: route
@@ -515,7 +515,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: architect
       - name: Stash the agent hooks
@@ -692,7 +692,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'architect') }}
           role: architect
@@ -749,7 +749,7 @@ jobs:
           cp "$RUNNER_TEMP/team-src/hooks/"*.py "$RUNNER_TEMP/agent-bin/"
           chmod +x "$RUNNER_TEMP/agent-bin"/*.py
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: claude
       - id: repairs-schema
@@ -850,7 +850,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'claude') }}
           role: claude
@@ -904,7 +904,7 @@ jobs:
           # on the first private consumer (#2). What holds this role's line is "no shell" (#665)
           # and the token's own narrow grant — not this flag.
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: researcher
       - name: Stash the agent hooks
@@ -1060,7 +1060,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'researcher') }}
           role: researcher
@@ -1157,19 +1157,19 @@ jobs:
       # same reason the hooks are stashed. A model step checks out a feature branch, and by
       # the Writer's turn the tree is whatever the Implementor left.
       - id: p_implementor
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: implementor
       - id: p_designer
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: designer
       - id: p_tester
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: tester
       - id: p_writer
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: writer
       - name: Stash the agent hooks
@@ -1868,7 +1868,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'authors') || steps.handoff.outputs.evidence == 'true' }}
           role: ${{ needs.delegate.outputs.roles }}
@@ -1924,7 +1924,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: security
       - id: security
@@ -1990,7 +1990,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'security') }}
           role: security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 ## Unreleased
 
+**Action required:** n/a — nothing has landed since `v2`.
+
+## v2
+
 **Action required:** yes — one stub input, one label re-sync, one overlay check.
 
 - **The stub gains a `runtimes` input.** It names the commands an authoring role may run, so it

--- a/templates/consumer-stub.yml
+++ b/templates/consumer-stub.yml
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write
       actions: read
       id-token: write
-    uses: matt-whitaker/claude-team/.github/workflows/team.yml@mainline
+    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v2
     with:
       project_owner: CHANGE-ME
       project_number: "0"


### PR DESCRIPTION
## ⚠️ This PR must not be merged

`CLAUDE.md`'s release procedure ends *"tag that commit `vN`, push the tag, and **do not merge the release commit** — mainline keeps its canary pins."* Merging this would put `v2` pins on `mainline`, so that this repo, `claude-team-example` and every consumer tracking `@mainline` would stop exercising the assets they are about to ship.

It is open as a **draft** for that reason, and only because a PR was asked for. The branch exists as a delivery vehicle for one commit.

### What to do instead

```bash
git fetch origin claude/festive-clarke-kmdnns
git tag -a v2 44f514ca7e4866c4ae845bd883fd113f50914cac -m "v2 — see CHANGELOG.md. Action required: yes."
git push origin v2
# then close this PR unmerged and delete the branch
git push origin --delete claude/festive-clarke-kmdnns
```

The tag has to be cut locally: this session's git relay 403s the `git-receive-pack` POST for a tag ref while the ref advertisement succeeds, and the GitHub MCP server exposes no create-tag or create-release tool.

## What is in the commit

`44f514c`, cut per the documented procedure:

- **`CHANGELOG.md`** — `## Unreleased` renamed to `## v2`, a fresh empty `## Unreleased` opened above it carrying `**Action required:** n/a`.
- **Every pin flipped `mainline` → `v2` in one commit** — `TEAM_REF`, the **15** composite-action `@refs` in `team.yml`, `load-prompt`'s default, and `templates/consumer-stub.yml`.
- **`.github/workflows/claude.yml` deliberately untouched.** `SelfInstall` pins this repo's own stub to `mainline` permanently; a blanket sweep across `.github` at release time is exactly what that test catches.

The four remaining `mainline` occurrences in `team.yml` are three comments and `base.ref == 'mainline'` — the default branch name, not a pin.

## Verification

- `python3 -m unittest discover -s tests` — **204 passed**.
- `ReleasePins` checked non-vacuous: mutating the stub pin to `v1` fails it; restored.

## Consumer impact

`v2` is an **Action required: yes** release — one stub input (`runtimes`), one label re-sync, one Writer-overlay check, plus the `types: [labeled, closed]` trigger. The fleet needs the `ONBOARDING.md` §0 pass, not just a ref bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn)_