### PR TITLE
Upgrade the harness rule to revision 7

### DIFF
--- a/.claude/rules/claude-harness.md
+++ b/.claude/rules/claude-harness.md
@@ -1,6 +1,6 @@
 # claude-harness
 
-**harness-rule-revision: 6** · from `matt-whitaker/claude-harness`
+**harness-rule-revision: 7** · from `matt-whitaker/claude-harness`
 
 ⚠️ **This file is entirely claude-harness's.** Nothing repo-specific goes in it. To upgrade,
 **replace it** — never merge. To uninstall, delete it.
@@ -51,6 +51,9 @@ confirmation rather than the trigger.
   instruction, so mark what is settled and what is genuinely open.
 - **Secrets never pass through a session.** They paste values into the GitHub or console UI; your
   job is to say exactly *which* values and *where* they go.
+- **Finished work ships as a PR, not as a pushed branch.** Push and open it in the same breath — a
+  branch nobody was told about is not delivered, however clearly the session described it. Say
+  plainly when a PR must *not* be merged rather than withholding it.
 - **Destructive and outward-facing work waits for an explicit instruction** — merging,
   force-pushing, deleting, anything beyond opening a PR. Approval in one context does not extend
   to the next.


### PR DESCRIPTION
The consumer half of `claude-harness` [#1](https://github.com/matt-whitaker/claude-harness/pull/1). `.claude/rules/claude-harness.md` replaced wholesale, which is the documented upgrade — nothing in the file is this repo's, so there is nothing to preserve and nothing to merge.

`harness-rule-revision` **6 → 7**. One line added, under *Working with the maintainer*:

> **Finished work ships as a PR, not as a pushed branch.** Push and open it in the same breath — a branch nobody was told about is not delivered, however clearly the session described it. Say plainly when a PR must *not* be merged rather than withholding it.

The rule already drew its boundary at *"anything beyond opening a PR"* but never said to open one, so a session read it as a ceiling, pushed a branch, described it accurately and waited to be asked. The new line completes that bullet rather than arguing with it: opening is the safe side, merging is still the maintainer's.

## Ordering

⚠️ **Merge `claude-harness` #1 first.** This file must match what the `v2` tag ships; if #1 changes before it lands, this copy needs re-taking from the merged source.

## Not to be confused with the other open PR here

[#67](https://github.com/matt-whitaker/claude-team/pull/67) is the `v2` release commit and **must not be merged** — it exists to carry a tag. This one is an ordinary change and merges normally. It branches from `mainline`, not from #67, so it carries none of the `v2` pin flips.

## Verification

`python3 -m unittest discover -s tests` — **204 passed**. The installed file is byte-identical to `claude-harness`'s source at the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn)_