### PR TITLE
End the release by checking the tag, not the checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,21 @@ exercise the engine tracks `@mainline` instead — brewdocs.beer as the canary, 
 as the drill target, and this repo's own stub, which `SelfInstall` pins there permanently.
 brewdocs.beer-kb also tracks `@mainline`, by the maintainer's call rather than by the rule.
 
+⚠️ **THE SUITE CANNOT SEE WHICH COMMIT GOT TAGGED, so the release ends with a check on the tag
+itself.** `ReleasePins` asserts the four pins agree with *each other* — on mainline they all read
+`mainline`, so it is green on exactly the tree a mis-cut tag ships. Nothing else looks either. The
+stub is the consumer's own pin, which makes it the sharpest single probe:
+
+```bash
+git show vN:templates/consumer-stub.yml | grep 'team.yml@'   # must print @vN, never @mainline
+```
+
+⚠️ **The plausible mis-cut is tagging the default branch's head.** The release commit is
+deliberately not on any branch, so every tool that defaults to a branch — the GitHub Releases page
+included — targets the wrong commit while looking exactly right. What ships is a `vN` whose jobs
+fetch every hook and prompt from `mainline` at run time and a stub telling the consumer to pin
+`@mainline`: pinning that pins nothing.
+
 ⚠️ **A release is not finished when the tag is pushed.** `ONBOARDING.md` §0 is the returning
 consumer's path and `CHANGELOG.md` is what makes it answerable. A consumer has one question — *must
 I act?* — so every version heading carries an explicit `**Action required:**` line and a test

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -447,6 +447,17 @@ class TheReturningConsumerHasAPath(unittest.TestCase):
         self.assertIn("Unreleased", release)
         self.assertIn("CHANGELOG.md", release)
 
+    def test_the_release_procedure_ends_by_checking_the_TAG(self):
+        """⚠️ THE ONE FAILURE THIS SUITE IS STRUCTURALLY BLIND TO. Every test here runs against a
+        checkout; none can see which commit a tag was put on. `ReleasePins` asserts the four pins
+        agree with each other, so it passes on mainline — where they all read `mainline` — which is
+        exactly the tree a tag cut from the default branch's head ships. The procedure has to carry
+        a check on the tag itself, and this asserts it still does."""
+        release = self.CLAUDEMD[self.CLAUDEMD.index("**Releasing**"):]
+        release = release[:release.index("## Working in this repo")]
+        self.assertIn("git show vN:templates/consumer-stub.yml", release)
+        self.assertIn("@mainline", release)
+
 
 class TheEmptyHandoffKeepsItsEvidence(unittest.TestCase):
     """⚠️ #32, second half. A role step that succeeds and returns no handoff silently halts a


### PR DESCRIPTION
Closes the gap that let `v2` ship pointing at the wrong commit.

## The blindness

**The suite cannot see which commit a tag was put on.** Every test here runs against a checkout. `ReleasePins` asserts the four pins agree with *each other* — on `mainline` they all read `mainline`, so it is **green on exactly the tree a mis-cut tag ships**. Nothing else looked either.

The release commit is deliberately not on any branch, so every tool that defaults to one — the GitHub Releases page included — targets the wrong commit *while looking exactly right*. What ships is a `vN` whose jobs fetch every hook and prompt from `mainline` at run time, and a `templates/consumer-stub.yml` telling the consumer to pin `@mainline`. **Pinning that pins nothing.**

## The change

`CLAUDE.md`'s release procedure now ends on the tag itself. The stub is the consumer's own pin, which makes it the sharpest single probe:

```bash
git show vN:templates/consumer-stub.yml | grep 'team.yml@'   # must print @vN, never @mainline
```

That command is what established `v1` and `v1.1` were cut correctly and `v2` was not.

## The test

`test_the_release_procedure_ends_by_checking_the_TAG` asserts the procedure still carries the step. It **cannot** assert the tag is right — that is the blindness being documented, not one this suite can close, and the docstring says so rather than implying coverage that does not exist.

## Verification

- New test proven to fail first: reverted `CLAUDE.md`, ran it against the unfixed doc, got `AssertionError: 'git show vN:templates/consumer-stub.yml' not found in ...`. Restored, it passes.
- `python3 -m unittest discover -s tests` — **205 passed** (204 + this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn)_