### PR TITLE
⚠️ DO NOT MERGE — v2 release commit, re-cut on current mainline

### DIFF
--- a/.github/actions/load-prompt/action.yml
+++ b/.github/actions/load-prompt/action.yml
@@ -34,7 +34,7 @@ inputs:
   ref:
     description: The ref of that repo to fetch
     required: false
-    default: mainline
+    default: v2
   overlay:
     description: The consumer's overlay directory
     required: false

--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -153,7 +153,7 @@ env:
   # the workflow fetches at run time. Release tooling must move both together — a drift check is
   # part of the release job, not optional.
   TEAM_REPO: matt-whitaker/claude-team
-  TEAM_REF: mainline
+  TEAM_REF: v2
 
 jobs:
   # ── Delegate ───────────────────────────────────────────────────────────────────
@@ -279,7 +279,7 @@ jobs:
           echo "routing schema loaded (${#body} chars)"
       - id: route-prompt
         if: steps.route.outputs.defaulted == 'true' || steps.route.outputs.consult == 'true'
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: route
       - id: custodian
@@ -478,7 +478,7 @@ jobs:
       - name: Capture the routing transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'route') }}
           role: route
@@ -515,7 +515,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: architect
       - name: Stash the agent hooks
@@ -692,7 +692,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'architect') }}
           role: architect
@@ -749,7 +749,7 @@ jobs:
           cp "$RUNNER_TEMP/team-src/hooks/"*.py "$RUNNER_TEMP/agent-bin/"
           chmod +x "$RUNNER_TEMP/agent-bin"/*.py
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: claude
       - id: repairs-schema
@@ -850,7 +850,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'claude') }}
           role: claude
@@ -904,7 +904,7 @@ jobs:
           # on the first private consumer (#2). What holds this role's line is "no shell" (#665)
           # and the token's own narrow grant — not this flag.
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: researcher
       - name: Stash the agent hooks
@@ -1060,7 +1060,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'researcher') }}
           role: researcher
@@ -1157,19 +1157,19 @@ jobs:
       # same reason the hooks are stashed. A model step checks out a feature branch, and by
       # the Writer's turn the tree is whatever the Implementor left.
       - id: p_implementor
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: implementor
       - id: p_designer
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: designer
       - id: p_tester
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: tester
       - id: p_writer
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: writer
       - name: Stash the agent hooks
@@ -1868,7 +1868,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'authors') || steps.handoff.outputs.evidence == 'true' }}
           role: ${{ needs.delegate.outputs.roles }}
@@ -1924,7 +1924,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
         with:
           role: security
       - id: security
@@ -1990,7 +1990,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'security') }}
           role: security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 ## Unreleased
 
+**Action required:** n/a — nothing has landed since `v2`.
+
+## v2
+
 **Action required:** yes — one stub input, one label re-sync, one overlay check.
 
 - **The stub gains a `runtimes` input.** It names the commands an authoring role may run, so it

--- a/templates/consumer-stub.yml
+++ b/templates/consumer-stub.yml
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write
       actions: read
       id-token: write
-    uses: matt-whitaker/claude-team/.github/workflows/team.yml@mainline
+    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v2
     with:
       project_owner: CHANGE-ME
       project_number: "0"


### PR DESCRIPTION
Supersedes [#67](https://github.com/matt-whitaker/claude-team/pull/67). Same purpose: a commit to hang the `v2` tag on. **Merging it would put `v2` pins on `mainline`** and stop this repo, `claude-team-example` and every `@mainline` consumer from exercising the assets they are about to ship.

## Why this exists

The published `v2` tag points at `359979b` — `mainline`'s head — not at a release commit. So `claude-team@v2` currently ships `TEAM_REF: mainline`, nine `load-prompt@mainline`, six `capture-transcript@mainline`, a stub reading `team.yml@mainline`, and a `CHANGELOG.md` with no `## v2` heading.

`v1` and `v1.1` both point at unmerged commits with the stub correctly pinned, so this is a one-off, not a standing pattern.

## What is in `95538fb`

Identical pin flips to #67, re-cut on top of the current default branch so **the tag becomes a strict superset of `mainline`** — it carries harness-rule revision 7 as well.

- `CHANGELOG.md` — `## Unreleased` → `## v2`, fresh empty one above it.
- `TEAM_REF`, the 15 composite-action `@refs`, `load-prompt`'s default, `templates/consumer-stub.yml` — all `mainline` → `v2`.
- `.github/workflows/claude.yml` untouched; `SelfInstall` pins it to `mainline` permanently.

## To fix the tag

```bash
git fetch origin claude/release-v2-recut
git tag -f v2 95538fb501c0b4d38412a0c36f74684db05767d1
git push --force origin v2
git show v2:templates/consumer-stub.yml | grep 'team.yml@'    # must print @v2
git push origin --delete claude/release-v2-recut claude/festive-clarke-kmdnns
```

⚠️ **That force-updates a published tag.** Blast radius is small — `v2` is hours old and no consumer has bumped to it — but anyone who already fetched keeps the stale object.

The alternative is #67's `44f514c`, which predates the revision-7 merge. Harmless either way: nothing in `team.yml` or the composite actions reads `.claude/`. Close whichever of the two PRs you do not use.

## Verification

`python3 -m unittest discover -s tests` — **204 passed** at `95538fb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn)_