### PR TITLE
Put mainline back on its canary pins

### DIFF
--- a/.github/actions/load-prompt/action.yml
+++ b/.github/actions/load-prompt/action.yml
@@ -34,7 +34,7 @@ inputs:
   ref:
     description: The ref of that repo to fetch
     required: false
-    default: v2
+    default: mainline
   overlay:
     description: The consumer's overlay directory
     required: false

--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -153,7 +153,7 @@ env:
   # the workflow fetches at run time. Release tooling must move both together — a drift check is
   # part of the release job, not optional.
   TEAM_REPO: matt-whitaker/claude-team
-  TEAM_REF: v2
+  TEAM_REF: mainline
 
 jobs:
   # ── Delegate ───────────────────────────────────────────────────────────────────
@@ -279,7 +279,7 @@ jobs:
           echo "routing schema loaded (${#body} chars)"
       - id: route-prompt
         if: steps.route.outputs.defaulted == 'true' || steps.route.outputs.consult == 'true'
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: route
       - id: custodian
@@ -478,7 +478,7 @@ jobs:
       - name: Capture the routing transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'route') }}
           role: route
@@ -515,7 +515,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: architect
       - name: Stash the agent hooks
@@ -692,7 +692,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'architect') }}
           role: architect
@@ -749,7 +749,7 @@ jobs:
           cp "$RUNNER_TEMP/team-src/hooks/"*.py "$RUNNER_TEMP/agent-bin/"
           chmod +x "$RUNNER_TEMP/agent-bin"/*.py
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: claude
       - id: repairs-schema
@@ -850,7 +850,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'claude') }}
           role: claude
@@ -904,7 +904,7 @@ jobs:
           # on the first private consumer (#2). What holds this role's line is "no shell" (#665)
           # and the token's own narrow grant — not this flag.
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: researcher
       - name: Stash the agent hooks
@@ -1060,7 +1060,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'researcher') }}
           role: researcher
@@ -1157,19 +1157,19 @@ jobs:
       # same reason the hooks are stashed. A model step checks out a feature branch, and by
       # the Writer's turn the tree is whatever the Implementor left.
       - id: p_implementor
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: implementor
       - id: p_designer
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: designer
       - id: p_tester
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: tester
       - id: p_writer
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: writer
       - name: Stash the agent hooks
@@ -1868,7 +1868,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'authors') || steps.handoff.outputs.evidence == 'true' }}
           role: ${{ needs.delegate.outputs.roles }}
@@ -1924,7 +1924,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: prompt
-        uses: matt-whitaker/claude-team/.github/actions/load-prompt@v2
+        uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: security
       - id: security
@@ -1990,7 +1990,7 @@ jobs:
       - name: Capture the transcript
         if: always()
         continue-on-error: true
-        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@v2
+        uses: matt-whitaker/claude-team/.github/actions/capture-transcript@mainline
         with:
           enabled: ${{ contains(vars.AGENT_TRANSCRIPTS, 'all') || contains(vars.AGENT_TRANSCRIPTS, 'security') }}
           role: security

--- a/templates/consumer-stub.yml
+++ b/templates/consumer-stub.yml
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write
       actions: read
       id-token: write
-    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v2
+    uses: matt-whitaker/claude-team/.github/workflows/team.yml@mainline
     with:
       project_owner: CHANGE-ME
       project_number: "0"


### PR DESCRIPTION
[#70](https://github.com/matt-whitaker/claude-team/pull/70)'s release commit was merged, so the four pins that should only ever exist on a tagged, unmerged commit landed on the default branch.

## The state it left

Exactly inverted — `mainline` carried `v2` pins while the `v2` tag carried `mainline` ones:

| | mainline (before this PR) | tag `v2` (`359979b`) |
|---|---|---|
| `TEAM_REF` | `v2` | `mainline` |
| `load-prompt@` / `capture-transcript@` | `v2` | `mainline` |
| stub template | `@v2` | `@mainline` |

The live effect was on **this repo**. Its own stub tracks `@mainline`, so a run here read `TEAM_REF: v2` and fetched every hook and prompt from the tag — meaning editing `hooks/` on mainline changed nothing about the run editing them. That is precisely the failure the canary exists to catch early, and it was silent.

`.github/workflows/claude.yml` was untouched throughout, so `SelfInstall` held.

## Order

⚠️ **Move the `v2` tag first, then merge this.** Current mainline (`e53b931`) is a correct v2 tree — v2 pins, `## v2` rolled, harness revision 8, #69's release check — so it is the natural tag target:

```bash
git tag -f v2 e53b931 && git push --force origin v2
git show v2:templates/consumer-stub.yml | grep 'team.yml@'    # must print @v2
```

Either order works, since that names a SHA rather than a branch — but tagging first means the tag captures the tree while it still has the v2 pins.

## What this deliberately does NOT revert

**`CHANGELOG.md` keeps its rolled `## v2` heading.** Reverting it would put v2's entries back under `## Unreleased`, where the next release would roll them into `## v3`.

⚠️ **That exposes a gap in the documented procedure, and it is worth a decision.** The roll happens only on the release commit, which is never merged — so nothing ever carries a `## vN` heading onto `mainline`. `## v1.1` and `## v1` are there only because `CHANGELOG.md` was authored retrospectively, after both were cut. Left alone, mainline's `## Unreleased` accumulates every shipped version's entries forever.

Merging #70 accidentally fixed that for v2. The general fix is a choice — a follow-up PR that rolls the heading on mainline after each tag, or the release commit landing its changelog half only — and it is a change to the release model, so I have not made it. Happy to open it either way.

## Verification

`python3 -m unittest discover -s tests` — **205 passed**. All four pins read `mainline` again, so `ReleasePins` agrees; `claude.yml` still `@mainline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn)_