### PR TITLE
Split the release commit; the changelog roll merges, the pins do not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,33 @@ scripted `team` stub (Python resolves imports from the script's own directory be
 imports the pure text helpers from the *real* `team.py` so they cannot drift, and runs every git-touching case against real repositories — including
 deliberately stale refs.
 
-⚠️ **Releasing**: check out mainline, rename `CHANGELOG.md`'s `## Unreleased` heading to `## vN`
-and open a fresh empty one above it, flip every pin (`TEAM_REF`, the in-workflow `@refs`,
-`load-prompt`'s default, the stub template) from `mainline` to `vN` in one commit, run the suite
-(`ReleasePins` asserts the agreement), tag that commit `vN`, push the tag, and **do not merge the
-release commit** — mainline keeps its canary pins. Consumers pin `@vN`; a repo whose job is to
+⚠️ **Releasing**: TWO COMMITS, and which one merges is the whole point. They have opposite
+requirements, so bundling them makes the harmless half inherit the dangerous half's constraint:
+
+1. **The changelog roll — an ordinary PR that MERGES.** Rename `CHANGELOG.md`'s `## Unreleased`
+   heading to `## vN` and open a fresh empty one above it. Nothing about this needs to be off
+   mainline.
+2. **The pin flip — a commit on top of that mainline, tagged, NEVER merged.** Flip every pin
+   (`TEAM_REF`, the in-workflow `@refs`, `load-prompt`'s default, the stub template) from
+   `mainline` to `vN`, run the suite (`ReleasePins` asserts the agreement), tag that commit `vN`
+   and push the tag. Mainline keeps its canary pins.
+
+⚠️ **Rolling FIRST is what puts the heading on both.** The tag is cut from a mainline that already
+carries `## vN`, so the artifact a consumer reads is correct, and so is the branch. Rolling
+afterwards instead would tag a tree whose own changelog says `## Unreleased`.
+
+⚠️ **Bundled, the roll never reached mainline at all** — it lived only on a commit that by
+definition does not merge. `## v1` and `## v1.1` are on the default branch only because
+`CHANGELOG.md` was written retrospectively, after both tags existed; the procedure has never
+produced a heading there. Left running, mainline's `## Unreleased` accumulates every shipped
+version and the next roll sweeps two releases under one heading — telling a consumer to redo
+actions they already took.
+
+⚠️ **Step 2 needs no branch**, only a commit that is not on mainline; a detached HEAD tags fine. A
+branch is worth pushing solely when the tag must be cut by someone else, since a tag cannot name a
+commit the remote does not have.
+
+Consumers pin `@vN`; a repo whose job is to
 exercise the engine tracks `@mainline` instead — brewdocs.beer as the canary, `claude-team-example`
 as the drill target, and this repo's own stub, which `SelfInstall` pins there permanently.
 brewdocs.beer-kb also tracks `@mainline`, by the maintainer's call rather than by the rule.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -458,6 +458,19 @@ class TheReturningConsumerHasAPath(unittest.TestCase):
         self.assertIn("git show vN:templates/consumer-stub.yml", release)
         self.assertIn("@mainline", release)
 
+    def test_the_release_is_two_commits_and_the_roll_merges_FIRST(self):
+        """⚠️ THE TWO HALVES HAVE OPPOSITE REQUIREMENTS. The changelog roll belongs on mainline;
+        the pin flip must never reach it. Bundled into one commit — as this procedure used to say
+        — the roll inherits the constraint it does not have, so no `## vN` heading ever lands on
+        the default branch and the next roll sweeps two releases under one heading. Order is the
+        other half: rolling first is what puts the heading on the tag as well as the branch."""
+        release = self.CLAUDEMD[self.CLAUDEMD.index("**Releasing**"):]
+        release = release[:release.index("## Working in this repo")]
+        roll, pins = release.index("The changelog roll"), release.index("The pin flip")
+        self.assertLess(roll, pins, "the changelog roll must be step 1")
+        self.assertIn("MERGES", release[roll:pins])
+        self.assertIn("NEVER merged", release[pins:])
+
 
 class TheEmptyHandoffKeepsItsEvidence(unittest.TestCase):
     """⚠️ #32, second half. A role step that succeeds and returns no handoff silently halts a


### PR DESCRIPTION
Documentation + one test. No behaviour, no workflow, no hook.

## The problem in one line

`CLAUDE.md` says to do two things **in one commit**, and that commit is the one that must never merge. Only one of the two things has any reason to be off mainline.

| half | must it stay off mainline? | why |
|---|---|---|
| flip the pins | **yes** | mainline carrying `vN` pins stops the default branch being a canary |
| roll `## Unreleased` → `## vN` | **no** | it is an ordinary edit; mainline is exactly where it belongs |

Bundled, the roll inherits a constraint it does not have. **The procedure has therefore never put a version heading on the default branch.** `## v1` and `## v1.1` are there only because `CHANGELOG.md` was written retrospectively, after both tags already existed — so nothing ever demonstrated the gap.

Left running: mainline's `## Unreleased` accumulates every shipped version, and the next roll sweeps two releases under one heading — telling a consumer to redo actions they already took.

## The change

Two steps instead of one commit:

1. **The changelog roll — an ordinary PR that MERGES.**
2. **The pin flip — a commit on top of that mainline, tagged, NEVER merged.**

⚠️ **Order is load-bearing, not cosmetic.** Rolling first means the tag is cut from a tree that already carries `## vN`, so the artifact a consumer reads is right *and* so is the branch. Rolling afterwards would tag a changelog still saying `## Unreleased`.

Also recorded: **step 2 needs no branch**, only a commit that is not on mainline — a detached HEAD tags fine. A branch is worth pushing solely when someone else has to cut the tag, since a tag cannot name a commit the remote does not have. (That is why this session pushed one; it cannot push tags.)

## Why this is strictly simpler than the alternative

The other option was a follow-up PR after each tag to land the roll. That is an extra step which, being last, is the one that gets skipped — and it would leave the tagged changelog saying `## Unreleased`. Splitting removes a step rather than adding one.

## The test

`test_the_release_is_two_commits_and_the_roll_merges_FIRST` asserts the roll is step 1, that its half says `MERGES`, and that the pin half says `NEVER merged`.

**Proven to fail first**: against the unfixed `CLAUDE.md` it errors `ValueError: substring not found`. It passes after.

The `**Releasing**` bold anchor is deliberately preserved — two existing tests index on that exact string, and losing it would have taken them down with a `ValueError` rather than a readable failure.

## Verification

`python3 -m unittest discover -s tests` — **206 passed** (205 + this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn)_