### PR TITLE
Releasing is the maintainer's; drop the procedure from this file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,29 +9,17 @@ scripted `team` stub (Python resolves imports from the script's own directory be
 imports the pure text helpers from the *real* `team.py` so they cannot drift, and runs every git-touching case against real repositories — including
 deliberately stale refs.
 
-⚠️ **Releasing**: check out mainline, rename `CHANGELOG.md`'s `## Unreleased` heading to `## vN`
-and open a fresh empty one above it, flip every pin (`TEAM_REF`, the in-workflow `@refs`,
-`load-prompt`'s default, the stub template) from `mainline` to `vN` in one commit, run the suite
-(`ReleasePins` asserts the agreement), tag that commit `vN`, push the tag, and **do not merge the
-release commit** — mainline keeps its canary pins. Consumers pin `@vN`; a repo whose job is to
-exercise the engine tracks `@mainline` instead — brewdocs.beer as the canary, `claude-team-example`
-as the drill target, and this repo's own stub, which `SelfInstall` pins there permanently.
-brewdocs.beer-kb also tracks `@mainline`, by the maintainer's call rather than by the rule.
+⚠️ **RELEASING IS THE MAINTAINER'S, AND NO SESSION DOES ANY PART OF IT.** Never tag, never flip a
+pin from `mainline` to a `vN`, never cut or merge a release commit. Say a release looks warranted,
+say what is in `## Unreleased` that a consumer would want, and stop. ⚠️ It is not a permissions
+gap to work around: a cloud session cannot push a tag at all, so the half it *can* do — a commit
+with the pins flipped — is the half that is dangerous on its own.
 
-⚠️ **THE SUITE CANNOT SEE WHICH COMMIT GOT TAGGED, so the release ends with a check on the tag
-itself.** `ReleasePins` asserts the four pins agree with *each other* — on mainline they all read
-`mainline`, so it is green on exactly the tree a mis-cut tag ships. Nothing else looks either. The
-stub is the consumer's own pin, which makes it the sharpest single probe:
-
-```bash
-git show vN:templates/consumer-stub.yml | grep 'team.yml@'   # must print @vN, never @mainline
-```
-
-⚠️ **The plausible mis-cut is tagging the default branch's head.** The release commit is
-deliberately not on any branch, so every tool that defaults to a branch — the GitHub Releases page
-included — targets the wrong commit while looking exactly right. What ships is a `vN` whose jobs
-fetch every hook and prompt from `mainline` at run time and a stub telling the consumer to pin
-`@mainline`: pinning that pins nothing.
+⚠️ **Consumers pin `@vN`**; a repo whose job is to exercise the engine tracks `@mainline` instead —
+brewdocs.beer as the canary, `claude-team-example` as the drill target, and this repo's own stub,
+which `SelfInstall` pins there permanently. brewdocs.beer-kb also tracks `@mainline`, by the
+maintainer's call rather than by the rule. ⚠️ **A `vN` appearing anywhere on `mainline` is a
+defect** — the default branch is what the canaries run, so a pin flipped there stops it being one.
 
 ⚠️ **A release is not finished when the tag is pushed.** `ONBOARDING.md` §0 is the returning
 consumer's path and `CHANGELOG.md` is what makes it answerable. A consumer has one question — *must

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -440,23 +440,30 @@ class TheReturningConsumerHasAPath(unittest.TestCase):
     def test_the_changelog_says_what_it_is_not(self):
         self.assertIn("not a merge log", self.CHANGELOG)
 
-    def test_the_release_procedure_renames_the_unreleased_heading(self):
-        """⚠️ A changelog nobody is told to roll over accumulates one permanent Unreleased section
-        and stops distinguishing versions — which is the whole mechanism §0 reads."""
-        release = self.CLAUDEMD[self.CLAUDEMD.index("**Releasing**"):][:600]
-        self.assertIn("Unreleased", release)
-        self.assertIn("CHANGELOG.md", release)
+    def test_releasing_is_the_maintainers_and_nothing_here_explains_how(self):
+        """⚠️ A session got every part of cutting a release wrong: a commit it could not tag, a tag
+        on the wrong object, a DO-NOT-MERGE PR merged. The half a cloud session CAN do — flipping
+        the pins — is the half that is dangerous alone, so the remedy is a prohibition rather than
+        a better-written procedure."""
+        self.assertIn("RELEASING IS THE MAINTAINER'S", self.CLAUDEMD)
+        self.assertIn("Never tag", self.CLAUDEMD)
 
-    def test_the_release_procedure_ends_by_checking_the_TAG(self):
-        """⚠️ THE ONE FAILURE THIS SUITE IS STRUCTURALLY BLIND TO. Every test here runs against a
-        checkout; none can see which commit a tag was put on. `ReleasePins` asserts the four pins
-        agree with each other, so it passes on mainline — where they all read `mainline` — which is
-        exactly the tree a tag cut from the default branch's head ships. The procedure has to carry
-        a check on the tag itself, and this asserts it still does."""
-        release = self.CLAUDEMD[self.CLAUDEMD.index("**Releasing**"):]
-        release = release[:release.index("## Working in this repo")]
-        self.assertIn("git show vN:templates/consumer-stub.yml", release)
-        self.assertIn("@mainline", release)
+    def test_no_release_MECHANICS_creep_back_into_this_file(self):
+        """⚠️ A procedure left lying about is one a session will follow, so the ban is asserted
+        rather than trusted to whoever edits next. The first two entries are the imperatives that
+        made the removed text actionable — they are what makes this guard bind today; the commands
+        after them are forward-looking, and would pass on their own."""
+        for mechanic in ("tag that commit", "flip every pin", "git tag", "git push --force"):
+            with self.subTest(mechanic=mechanic):
+                self.assertNotIn(mechanic, self.CLAUDEMD)
+
+    def test_the_changelog_discipline_survives_the_procedure(self):
+        """⚠️ THE HALF THAT MUST NOT GO WITH IT. `## Unreleased` only works because every PR writes
+        its own entry; that instruction is addressed to every session, not to whoever releases. Cut
+        with the procedure, the file degrades to the merge log it exists to replace — and CLAUDE.md
+        is the copy that loads into context, so CHANGELOG.md restating it is not a substitute."""
+        self.assertIn("written in the PR that causes it", self.CLAUDEMD)
+        self.assertIn("## Unreleased", self.CLAUDEMD)
 
 
 class TheEmptyHandoffKeepsItsEvidence(unittest.TestCase):


### PR DESCRIPTION
Your call, built. **Supersedes [#73](https://github.com/matt-whitaker/claude-team/pull/73)** — close that one; it rewrites a procedure this removes.

Net: **−34 / +33 in `CLAUDE.md`**, procedure gone.

## Why this beats fixing the procedure

A session got every part of cutting a release wrong today: a release commit it could not tag, a tag landing on the default branch's head, a DO-NOT-MERGE PR merged, and a changelog roll that by construction never reached mainline. #73 rewrote the procedure — which was answering the wrong question. The failure was that a session was following one at all.

⚠️ **And it is not a permissions gap to route around.** A cloud session cannot push a tag, so the only half it *can* perform is flipping the pins — and that half alone is exactly what puts `vN` refs on the default branch and stops the canaries being canaries. The capability it has is the dangerous one.

## What I did NOT delete, and this is the judgement call

Three things in that section were not procedure:

1. ⚠️ **"The CHANGELOG entry is written in the PR that causes it."** This is addressed to **every** session, not to whoever releases, and it is the only reason `## Unreleased` works at all. Cut it with the procedure and the file degrades into the merge log it exists to replace. `CHANGELOG.md` says it too, but **`CLAUDE.md` is the copy that loads into context** — so that is not a substitute.
2. Who pins `@vN` and who tracks `@mainline`, now with the sharper statement that **a `vN` anywhere on `mainline` is a defect**.
3. The consumer contract, untouched.

If you want 1 gone as well, say so — but it is the line that keeps the changelog answerable, and it costs a session nothing.

## Tests

Two asserting procedure wording are deleted. Three replace them:

| test | asserts |
|---|---|
| `..._releasing_is_the_maintainers_...` | the prohibition is stated |
| `..._no_release_MECHANICS_creep_back_...` | `tag that commit`, `flip every pin`, `git tag`, `git push --force` absent |
| `..._the_changelog_discipline_survives_...` | the PR-writes-its-own-entry rule is still there |

Both new guards **proven to fail against the old file** (`FAILED (failures=2)` for the mechanics one, after I caught that my first version of it was vacuous — it checked only for commands the old text never contained, so it passed either way).

`python3 -m unittest discover -s tests` — **206 passed**.

## One note

`.claude-team/prompts/_shared.md` already told the **roles** *"Releases are the maintainer's."* It was never said to the interactive sessions that actually do this work — which is the gap this closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn)_