### PR TITLE
Default allowed_bots to the account-wide dispatch App

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -128,9 +128,9 @@ on:
         type: string
         required: true
       allowed_bots:
-        description: Comma-separated bot logins admitted at the model steps (the dispatch App). Empty admits none.
+        description: Comma-separated bot logins admitted at the model steps (the dispatch App). Empty admits none; the default is this fleet's dispatch App.
         type: string
-        default: ""
+        default: "mattwhitaker-claude"
       node:
         description: Set up Node with npm cache and run npm ci before author runs
         type: boolean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 ## Unreleased
 
-**Action required:** n/a — nothing has landed since `v2`.
+**Action required:** yes — but only if your stub names the old App slug.
+
+- **`allowed_bots` now defaults to `mattwhitaker-claude`**, the account-wide dispatch App
+  (renamed from `brewdocs-claude`). An explicit value in your stub still overrides — including
+  an explicit `""`, which keeps the cascade dark. Consequence of the **rename**, independent of
+  the default: a stub still admitting `brewdocs-claude` names a slug that no longer exists, and
+  every cascaded run is refused at setup with *"Workflow initiated by non-human actor"* — update
+  it to `mattwhitaker-claude`. The cascade still requires the App installed on the repository
+  and its secrets set; the default only admits it.
 
 ## v2
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -73,11 +73,12 @@ workflow from the default branch.
 Settle these before touching files; each is a judgment call about the target, not boilerplate.
 
 - **`project_owner` / `project_number`** — the GitHub Projects board its issues and PRs go on.
-- **`allowed_bots`** — `""` unless a dispatch App is installed on the target. Empty means the
-  task cascade is **dark**: a finished task will not dispatch the next one, and the maintainer's
-  label gesture drives everything. That is the correct starting state — the cascade is an
-  upgrade, not a prerequisite — and the value is flipped to the App's slug later, when the App
-  half of step 6 happens. ⚠️ Name the App, never `*`: a wildcard admits any App on GitHub.
+- **`allowed_bots`** — defaults to `mattwhitaker-claude`, the account-wide dispatch App. Leave
+  it if that App is (or will be) installed on the target; set `""` to run the cascade **dark** —
+  a finished task will not dispatch the next one, and the maintainer's label gesture drives
+  everything, which is a valid starting state. ⚠️ The default only *admits* the App: the cascade
+  also needs the App installed on the repository and its secrets set (step 6), or dispatch stays
+  a `::notice::`. ⚠️ Name an App, never `*`: a wildcard admits any App on GitHub.
 - **`node`** — `true` if any author needs a runtime to install or build with; a repo whose gate
   is `npm run <anything>` wants it even with zero dependencies. ⚠️ `true` requires a
   **committed `package-lock.json`**, even with zero dependencies: `actions/setup-node`'s npm

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ not happen, never as a failure.
 |---|---|---|
 | `project_owner` | yes | the board's URL — the user or org that owns it |
 | `project_number` | yes | the board's URL, `…/projects/<N>` |
-| `allowed_bots` | no | the dispatch App's login, `<app-slug>[bot]`. Empty admits none |
+| `allowed_bots` | no | the dispatch App's login. Defaults to `mattwhitaker-claude`, the fleet's App; `""` admits none |
 | `node` | no | your call — `true` runs `npm ci` before author runs |
 | `browser` | no | your call — `true` installs the Playwright chromium |
 | `runtimes` | no | **your repo's gate** — the commands an author must be able to run. Defaults to `npm,npx,node` |

--- a/templates/consumer-stub.yml
+++ b/templates/consumer-stub.yml
@@ -56,7 +56,10 @@ jobs:
     with:
       project_owner: CHANGE-ME
       project_number: "0"
-      allowed_bots: ""
+      # The fleet's dispatch App, admitted at the model steps so a finished task can
+      # cascade the next. Set "" to run the cascade dark; never `*`, which admits any
+      # App on GitHub with a prompt it controls.
+      allowed_bots: mattwhitaker-claude
       node: false
       browser: false
       # The commands an authoring role may run, so it can execute THIS repo's gate.


### PR DESCRIPTION
`brewdocs-claude` is renamed `mattwhitaker-claude` and is now the account-wide dispatch App — one App, whole fleet, maintainer's decision. With one constant value, the empty default stopped buying anything: every install's first cascaded run was refused at setup until the same slug was copied into the same input, and mattwhitaker.name paid exactly that run this week.

**What changes**: the `allowed_bots` input default (`""` → `mattwhitaker-claude`), the template stub (carries the slug explicitly, with the never-`*` warning kept), README's input table, ONBOARDING §1's bullet, and a CHANGELOG entry.

**What doesn't**: an explicit stub value still overrides — including explicit `""`, which is how fantasy-football deliberately runs dark today, so no running consumer changes behavior. The default only *admits* the App; a cascade still needs the App installed on the repository and its secrets set. `*` remains forbidden.

**The rename's own consequence, recorded in the CHANGELOG**: a stub still admitting `brewdocs-claude` names a slug that no longer exists and refuses every cascaded run. Both brewdocs stubs have that today — sibling PRs fix them.

**Not tagged**, per the maintainer — mainline-tracking consumers pick this up on merge; pinned consumers at their next bump.

Gate: 206 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)