### PR TITLE
Give a session in a consumer repo a rule of its own

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,16 @@ unconditionally.
 role may do reaches nothing while an overlay still grants it. §0 says to grep for the old grant
 whenever an entry reports a narrowed scope.
 
+⚠️ **`rules/claude-team.md` is what a SESSION in a consumer repo knows.** The stub and the
+overlays tell a *workflow* how to run; neither tells a person's session what an epic is or where
+work goes, and claude-team's own `CLAUDE.md` is not in that clone. ⚠️ **It carries `team-ref`,
+which is the `uses:` pin recorded where a session reads it — not a second version number.** The
+pin is still the signal; this makes it legible from the clone, and a `team-ref` disagreeing with
+the stub is a half-done upgrade, the only part of one a clone can detect alone. ⚠️ **No role
+instruction goes in it** — a role is given `prompts/` at run time, and a rule scopes by file path,
+never by who is running. ⚠️ Its hierarchy table is asserted equal to this file's, because a third
+statement of the same facts is a third thing that drifts.
+
 ⚠️ **The consumer contract**: `team.yml` is a reusable workflow (`on: workflow_call`). A consumer
 holds the frozen stub (`templates/consumer-stub.yml`) plus a `.claude-team/` directory — `prompts/`
 overlays (`_shared.md` required) and an optional executable `setup.sh`. Inputs: `project_owner`,

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -33,10 +33,12 @@ Then, in order:
    heading carries an `**Action required:**` line. If they all say `no`, steps 2 and 5 are the
    whole upgrade.
 
-2. **Bump the `uses:` ref.** It is the only pin a consumer holds — `TEAM_REF` lives inside the
-   workflow and moves with the tag, so a consumer never edits it and must never be told to.
-   ⚠️ A repo that deliberately tracks `@mainline` skips this; see the release note in `CLAUDE.md`
-   for which ones and why.
+2. **Bump the `uses:` ref, and the rule's `team-ref` with it.** That ref is the
+   only pin a consumer holds — `TEAM_REF` lives inside the workflow and moves with the tag, so a
+   consumer never edits it and must never be told to. ⚠️ **Re-fetch `.claude/rules/claude-team.md` from the
+   new ref** (§2) and check its `team-ref` matches: the two are one fact in two places, and a
+   mismatch is exactly the half-done upgrade nothing else can see. ⚠️ A repo that deliberately
+   tracks `@mainline` skips the bump; see the release note in `CLAUDE.md` for which ones and why.
 
 3. **Reconcile the stub — do not recreate it.** Diff it against
    [`templates/consumer-stub.yml`](templates/consumer-stub.yml). Everything but the header comment,
@@ -104,6 +106,25 @@ ceiling the team's jobs draw down from, not a grant to the stub itself. Cutting 
 
 If authors need setup beyond installing dependencies, add an executable `.claude-team/setup.sh`
 ([`templates/setup.sh.example`](templates/setup.sh.example)); otherwise omit it.
+
+### The rule, written in this same step
+
+A consumer's clone holds the stub and the overlays, and neither tells a **session** opened against
+that repo what the team is. Install the rule that does, from the same tag you just pinned:
+
+```bash
+mkdir -p <target>/.claude/rules
+curl -fsSL https://raw.githubusercontent.com/matt-whitaker/claude-team/vN/rules/claude-team.md \
+  -o <target>/.claude/rules/claude-team.md
+```
+
+⚠️ **Set its `team-ref` to the ref you pinned above.** It is not a second version number — it is
+the pin, recorded where a session reads rather than where a workflow does, and it is why the two
+are written in one step. ⚠️ **A `team-ref` that disagrees with the `uses:` pin is a half-done
+upgrade**, and the only part of one a clone can detect on its own.
+
+⚠️ **It carries no role instruction.** A role is given `prompts/` at run time; a rule scopes by
+file path, never by who is running.
 
 ## 3. The overlays — where the target's personality lives
 

--- a/rules/claude-team.md
+++ b/rules/claude-team.md
@@ -1,0 +1,60 @@
+# claude-team
+
+**team-ref: v2** · from `matt-whitaker/claude-team`
+
+⚠️ **This file is entirely claude-team's.** Nothing repo-specific goes in it. To upgrade, **replace
+it** — never merge. To uninstall, delete it.
+
+⚠️ **`team-ref` must equal the `uses:` pin in `.github/workflows/claude.yml`.** They are one fact
+in two places — which version of the team this repo runs. A mismatch is a half-done upgrade, and it
+is the only part of one a clone can detect on its own.
+
+⚠️ **This is what a SESSION needs. The roles do not read it.** A role running inside a workflow is
+given `prompts/_shared.md` + `prompts/<role>.md`, fetched at the pin. Role-scoped instruction never
+belongs here: a rule scopes by file path, never by who is running.
+
+## What is installed
+
+| | |
+|---|---|
+| `.github/workflows/claude.yml` | the stub — triggers, inputs, and the `uses:` pin, the only pin you hold |
+| `.claude-team/prompts/` | your overlays. `_shared.md` required, `<role>.md` optional |
+| `.claude-team/setup.sh` | optional, executable |
+| `.claude/rules/claude-team.md` | this file |
+
+## The issue hierarchy
+
+| level | branch | its PR targets | closed by |
+|---|---|---|---|
+| **Epic** | none | — | its stories closing |
+| **Spike** | none | — | the maintainer, once they have decided |
+| **Story** | `<story#>-<summary>`, named by the Architect | the **default** branch | its PR merging |
+| **Task** | none of its own — its work lands on the story's branch | — | a hook, once its work has landed |
+
+⚠️ **A task has no PR, and there is exactly one PR per story.** Its absence before the last task
+closes is the design, not a failure.
+
+⚠️ **An unprocessed issue is a STORY.** An epic has to say so — an `epic` label, or a title
+beginning "Epic". Having sub-issues does not make one: a story has those too, they are its tasks.
+
+## Starting a run
+
+- **A label on an issue is the front door.** Applying it starts a run, and a script picks the role
+  from the issue's state. ⚠️ **Applying it is the maintainer's gesture** — a session does not label
+  an issue to make something happen.
+- The same handle in a **comment** does the same. `@claude/<role>` names the role outright and
+  skips the inspection.
+- ⚠️ **A run executes the hooks and prompts at the PIN, never from this clone.** Editing your
+  overlays on a branch changes nothing about the run editing them.
+
+## Where work goes
+
+⚠️ **Work goes on the branch of the thing the run was triggered on** — not a branch a model picks.
+An issue trigger means a fresh task branch and one PR at the story level; a PR trigger means
+commits on that PR's branch and no new PR.
+
+## What this file does not carry
+
+Everything else lives in [`claude-team`](https://github.com/matt-whitaker/claude-team) — its
+`CLAUDE.md`, its install runbook, its prompts and its hooks. Read it there. ⚠️ **Nothing here
+summarises them**: a copy drifts, and the copy is what gets read.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -466,6 +466,51 @@ class TheReturningConsumerHasAPath(unittest.TestCase):
         self.assertIn("## Unreleased", self.CLAUDEMD)
 
 
+class TheRuleASessionReads(unittest.TestCase):
+    """⚠️ A consumer's clone holds the stub and the overlays, and neither tells a SESSION opened
+    against that repo what an epic is or where work goes — claude-team's own CLAUDE.md is not in
+    that clone. `rules/claude-team.md` is that install, and these pin the two things that make it
+    safe rather than a third drifting copy."""
+
+    ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+    def setUp(self):
+        self.RULE = (self.ROOT / "rules/claude-team.md").read_text()
+        self.CLAUDEMD = (self.ROOT / "CLAUDE.md").read_text()
+        self.ONBOARDING = (self.ROOT / "ONBOARDING.md").read_text()
+
+    @staticmethod
+    def _levels(text):
+        """The bolded first cell of every row in the issue-hierarchy table."""
+        table = text[text.index("| level | branch |"):]
+        table = table[:table.index("\n\n")]
+        return [r.split("|")[1].strip() for r in table.splitlines()[2:]]
+
+    def test_it_records_the_PIN_rather_than_inventing_a_version(self):
+        """⚠️ THE DECISION THIS COULD HAVE COLLIDED WITH. ONBOARDING already refuses a revision
+        integer because `the pin *is* the signal`. `team-ref` is not a second number — it is that
+        pin, written where a session reads instead of where a workflow does, which is why the two
+        are set in one step and why disagreement is a defect rather than a version skew."""
+        self.assertRegex(self.RULE, r"\*\*team-ref: \S+\*\*")
+        self.assertIn("the pin *is* the signal", self.ONBOARDING)
+        self.assertIn("team-ref", self.ONBOARDING)
+
+    def test_its_hierarchy_cannot_drift_from_CLAUDE_md(self):
+        """⚠️ A third statement of the same facts is a third thing that drifts, and prose review
+        does not catch a missing table row. Asserted against CLAUDE.md, which is the session-facing
+        source this file is an extract of."""
+        self.assertEqual(self._levels(self.RULE), self._levels(self.CLAUDEMD))
+
+    def test_it_carries_no_ROLE_instruction(self):
+        """⚠️ A rule scopes by file path, never by who is running — so a role's instructions cannot
+        become one. Roles are given `prompts/` at run time; this file is read by everyone in the
+        repo, including a person's session that is not a role at all."""
+        self.assertIn("never by who is running", self.RULE)
+        for role_shaped in ("You are the", "Your task is", "Role: implementor"):
+            with self.subTest(text=role_shaped):
+                self.assertNotIn(role_shaped, self.RULE)
+
+
 class TheEmptyHandoffKeepsItsEvidence(unittest.TestCase):
     """⚠️ #32, second half. A role step that succeeds and returns no handoff silently halts a
     story, and WHY it produced nothing is unknowable from anything else the run keeps. On the run


### PR DESCRIPTION
New `rules/claude-team.md` (60 lines), installed into a consumer's `.claude/rules/` the way the harness rule is — one file, replaced wholesale to upgrade.

## The gap it closes

A consumer's clone holds the stub and the overlays. Neither tells a **session** opened against that repo what an epic is, where work goes, or what starts a run — and claude-team's `CLAUDE.md` is not in that clone. The only instruction reaching such a session was the harness rule's *"go read `claude-team`"*, which in a cloud session cannot be followed until someone attaches this repo.

## `team-ref` is not a second version number

This is the decision it could have collided with. `ONBOARDING.md` already refuses a revision integer, and the reasoning is specific:

> Copying claude-code's revision integer would be wrong: it needed one because **its install target is a session's knowledge and nothing else numbered it**. Here the pin already is the version.

That reasoning holds and points the same way: **the pin versions the workflow**; it does not version what a session knows. So `team-ref` records that same pin where a session reads it, rather than inventing a fact.

Two consequences, both deliberate:

- It is written in **§2, the same step as the stub's `uses:` ref** — one value, two places, set together.
- ⚠️ **A `team-ref` disagreeing with the `uses:` pin is a half-done upgrade** — and the only part of one a clone can detect on its own. §0 step 2 now moves both.

## What it deliberately does not carry

**No role instruction.** A rule scopes by file path, never by who is running — the constraint claude-harness already states. Roles keep getting `prompts/_shared.md` + `prompts/<role>.md` at run time; this file is read by everyone in the repo, including a person's session that is not a role at all. Asserted.

## Tests (3 new, 209 total)

| test | asserts |
|---|---|
| `..._records_the_PIN_rather_than_inventing_a_version` | `team-ref` present; ONBOARDING still says the pin is the signal |
| `..._its_hierarchy_cannot_drift_from_CLAUDE_md` | the hierarchy table's rows equal `CLAUDE.md`'s |
| `..._it_carries_no_ROLE_instruction` | the scoping constraint is stated; no role-shaped text |

The drift guard is **proven to bind**: deleting the Spike row from the rule fails it.

## Two findings, neither fixed here

1. ⚠️ **`prompts/_shared.md` and `CLAUDE.md` have already drifted** — the roles' hierarchy table has **no Spike row**, and the wording differs (*"named by"* vs *"cut by"*, `work-completion.py` vs *"a hook"*). That is the third-copy problem arriving before the third copy, and it is why this PR asserts rather than trusts. Out of scope; worth filing.
2. An existing test indexes on the literal `only pin a consumer holds`, and my first §0 edit line-wrapped between `a` and `consumer`, breaking it. Caught by the suite, rewrapped. Noting it because the phrase is load-bearing and invisible as such.

## Not included

Whether **this repo** installs its own rule. It is its own decision — this repo has `CLAUDE.md` already, so a session here loses nothing by not having it, and self-installing means a second copy to keep in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMzy5eg8fyGFaCQRkjrRn)_