### PR TITLE
Ask the maintainer for the App slug at install, beside the board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 ## Unreleased
 
-**Action required:** n/a — nothing has landed since `v2`.
+**Action required:** no — install-runbook change only; nothing for an existing consumer.
+
+- The install now asks the maintainer for the dispatch App'''s slug outright, beside the board,
+  instead of deferring it to the App half of step 6. Prompted by an App rename: a stub admitting
+  a stale slug refuses every cascaded run at setup, and the runbook now asks for the current
+  name even when the installer thinks they know it.
 
 ## v2
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -68,16 +68,24 @@ Then, in order:
 branch, and remember nothing takes effect until merge, because `issues` events always run the
 workflow from the default branch.
 
-## 1. Decide the four inputs
+## 1. Decide the inputs
 
 Settle these before touching files; each is a judgment call about the target, not boilerplate.
+⚠️ **Two of them are answers only the maintainer holds** — the board (`project_owner` /
+`project_number`) and the dispatch App's slug. They are not derivable from the target repo:
+**ask, and do not proceed on a guess.** Every other input you can settle by reading the repo.
 
 - **`project_owner` / `project_number`** — the GitHub Projects board its issues and PRs go on.
-- **`allowed_bots`** — `""` unless a dispatch App is installed on the target. Empty means the
-  task cascade is **dark**: a finished task will not dispatch the next one, and the maintainer's
-  label gesture drives everything. That is the correct starting state — the cascade is an
-  upgrade, not a prerequisite — and the value is flipped to the App's slug later, when the App
-  half of step 6 happens. ⚠️ Name the App, never `*`: a wildcard admits any App on GitHub.
+- **`allowed_bots`** — **ask the maintainer for the dispatch App's current slug**, the same way
+  you ask for the board. Two questions, asked outright: *should the cascade drive this repo*,
+  and *what is the App named right now*. ⚠️ Ask for the name even if you think you know it —
+  Apps get renamed, the slug is the identity, and a stub admitting a stale slug refuses every
+  cascaded run at setup with *"Workflow initiated by non-human actor"*. The answer `""` is the
+  explicit decision to start **dark**: a finished task will not dispatch the next one, and the
+  maintainer's label gesture drives everything — a valid starting state, since the cascade is an
+  upgrade, not a prerequisite. ⚠️ The slug only *admits* the App: the cascade also needs the App
+  installed on the repository and its secrets set (step 6). ⚠️ Name the App, never `*`: a
+  wildcard admits any App on GitHub.
 - **`node`** — `true` if any author needs a runtime to install or build with; a repo whose gate
   is `npm run <anything>` wants it even with zero dependencies. ⚠️ `true` requires a
   **committed `package-lock.json`**, even with zero dependencies: `actions/setup-node`'s npm

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -380,7 +380,7 @@ class TheReturningConsumerHasAPath(unittest.TestCase):
         """⚠️ A returning reader must not have to read §1-§7 to discover they are in the wrong
         place — §3 would overwrite an overlay carrying the repo's whole personality."""
         upgrade = self.ONBOARDING.index("## 0. Already installed?")
-        first_install_step = self.ONBOARDING.index("## 1. Decide the four inputs")
+        first_install_step = self.ONBOARDING.index("## 1. Decide the inputs")
         self.assertLess(upgrade, first_install_step)
 
     def test_the_install_steps_are_signposted_as_not_for_a_returning_reader(self):


### PR DESCRIPTION
Replaces #75 (closed), per the maintainer: no hard-coded default — the install treats the dispatch App's slug as one of the **answers only the maintainer holds**, asked outright beside the board.

**ONBOARDING §1**:
- New intro warning: the board and the App slug are not derivable from the target repo — *ask, and do not proceed on a guess*.
- The `allowed_bots` bullet becomes two direct questions: *should the cascade drive this repo*, and *what is the App named right now* — with the rename failure named, so ask-even-if-you-think-you-know carries its reason. A stub admitting a stale slug refuses every cascaded run at setup with *"Workflow initiated by non-human actor"*.
- `""` stays the explicit, valid dark start; the slug only *admits* the App (install + secrets remain step 6); `*` remains forbidden.
- The heading drops its stale count ("the four inputs" — there are six). One test anchored on the old heading text updated with it.

**CHANGELOG**: action required **no** — runbook change only. The stale-slug breakage on existing stubs is fixed by [brewdocs.beer#1336](https://github.com/matt-whitaker/brewdocs.beer/pull/1336) and [brewdocs.beer-kb#45](https://github.com/matt-whitaker/brewdocs.beer-kb/pull/45), which stand regardless.

Gate: 206 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
