### PR TITLE
Give the verbs one entry point, so both drivers invoke identical code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 ## Unreleased
 
-**Action required:** no — install-runbook change only; nothing for an existing consumer.
+**Action required:** no — nothing for an existing consumer.
 
-- The install now asks the maintainer for the dispatch App'''s slug outright, beside the board,
+- **`hooks/run.py` is one entry point for the deterministic verbs** — `--list` names them, an
+  unknown verb fails naming the known set, and a verb runs its hook with the caller's env and
+  exit code. Adds no behaviour; it exists so a session driving a story invokes the same code a
+  CI step does (epic #78, the verbs story). Nothing in `team.yml` changes.
+- The install now asks the maintainer for the dispatch App's slug outright, beside the board,
   instead of deferring it to the App half of step 6. Prompted by an App rename: a stub admitting
   a stale slug refuses every cascaded run at setup, and the runbook now asks for the current
   name even when the installer thinks they know it.

--- a/hooks/run.py
+++ b/hooks/run.py
@@ -1,0 +1,66 @@
+"""One entry point for the deterministic verbs, so both drivers invoke identical code.
+
+A CI step runs a hook as `python3 hooks/<name>.py` with its inputs in env. A session driving a
+story needs the same verbs against its own checkout — and "find the right script and remember its
+name" is exactly the kind of instruction that gets half-remembered. This dispatcher makes the
+verb set discoverable and the invocation uniform:
+
+    python3 hooks/run.py --list          # every verb, with what it does
+    ISSUE=72 python3 hooks/run.py work-completion
+
+It adds NO behaviour: a verb is a hook script, executed with the caller's env, exiting with the
+hook's own exit code. Inputs stay env vars — the contract the hooks already have — so nothing
+here parses arguments on a hook's behalf.
+
+⚠️ Verbs are derived from the directory listing, never enumerated here. This package already
+learned that a hand-kept roster of its own parts drifts (four role enumerations, no two agreeing
+— see the epic on role opt-in). `team.py` is the library and this file is the dispatcher; both
+are excluded because neither is a verb.
+
+⚠️ An unknown verb fails NAMING THE KNOWN SET. Failing loudly is not the same as failing
+usefully (RULES.md E8): the caller who typo'd a verb should not need a second command to learn
+what was available.
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+NOT_VERBS = {"run.py", "team.py"}
+
+
+def verbs() -> dict[str, str]:
+    """Verb name -> first docstring line, derived from the directory."""
+    found = {}
+    for script in sorted(HERE.glob("*.py")):
+        if script.name in NOT_VERBS:
+            continue
+        summary = ""
+        for line in script.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith(('"""', "'''")):
+                summary = line.strip("\"'").strip()
+                break
+        found[script.stem] = summary
+    return found
+
+
+def main(argv: list[str]) -> int:
+    known = verbs()
+    if not argv or argv[0] in ("--list", "-l"):
+        width = max(len(v) for v in known)
+        for name, summary in known.items():
+            print(f"{name:<{width}}  {summary}")
+        return 0
+    verb = argv[0]
+    if verb not in known:
+        print(f"unknown verb: {verb}", file=sys.stderr)
+        print(f"known: {', '.join(known)}", file=sys.stderr)
+        return 2
+    return subprocess.run([sys.executable, str(HERE / f"{verb}.py"), *argv[1:]]).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,70 @@
+"""The dispatcher is only trustworthy if its verb set cannot drift from the directory.
+
+`run.py` derives verbs from `hooks/*.py` at call time, so the thing to assert is the derivation
+itself — every hook is a verb, the two non-verbs are excluded — plus the two behaviours a caller
+leans on: an unknown verb fails naming the known set (E8: failing loudly is not failing
+usefully), and a verb executes its script with the caller's env and returns the script's own
+exit code.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+HOOKS = ROOT / "hooks"
+
+
+def run(args, cwd=HOOKS, env=None):
+    return subprocess.run(
+        [sys.executable, str(HOOKS / "run.py"), *args],
+        capture_output=True, text=True, cwd=cwd, env=env,
+    )
+
+
+class Dispatcher(unittest.TestCase):
+    def test_every_hook_is_a_verb_and_the_non_verbs_are_not(self):
+        listed = run(["--list"])
+        self.assertEqual(listed.returncode, 0, listed.stderr)
+        names = {line.split()[0] for line in listed.stdout.splitlines() if line.strip()}
+        on_disk = {p.stem for p in HOOKS.glob("*.py")} - {"run", "team"}
+        self.assertEqual(names, on_disk,
+                         "the verb list must be exactly the hooks directory minus the library "
+                         "and the dispatcher — a roster that drifts is the defect this derives "
+                         "its way around")
+        self.assertNotIn("team", names)
+        self.assertNotIn("run", names)
+
+    def test_an_unknown_verb_fails_naming_the_known_set(self):
+        r = run(["no-such-verb"])
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("unknown verb: no-such-verb", r.stderr)
+        self.assertIn("delegate", r.stderr,
+                      "the failure must name the known verbs, or the caller needs a second "
+                      "command to learn what was available")
+
+    def test_a_verb_runs_its_script_with_env_and_returns_its_exit_code(self):
+        # A scratch copy with one fake verb, so the test exercises dispatch itself
+        # rather than any real hook's behaviour.
+        tmp = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        shutil.copy(HOOKS / "run.py", tmp / "run.py")
+        (tmp / "probe.py").write_text(
+            '"""A probe verb."""\n'
+            "import os, sys\n"
+            "print(os.environ.get('PROBE_INPUT', 'missing'))\n"
+            "sys.exit(7)\n",
+            encoding="utf-8",
+        )
+        env = dict(os.environ, PROBE_INPUT="carried")
+        r = subprocess.run(
+            [sys.executable, str(tmp / "run.py"), "probe"],
+            capture_output=True, text=True, env=env,
+        )
+        self.assertEqual(r.returncode, 7, "the hook's own exit code must pass through")
+        self.assertIn("carried", r.stdout, "the caller's env must reach the hook")


### PR DESCRIPTION
The verbs story from epic [#78](https://github.com/matt-whitaker/claude-team/issues/78) — the smallest executable slice of the two-driver architecture.

**`hooks/run.py`**: one entry point for the deterministic verbs.

```
python3 hooks/run.py --list          # every verb, with what it does
ISSUE=72 python3 hooks/run.py work-completion
```

- **Adds no behaviour.** A verb is a hook script, executed with the caller's env, exiting with the hook's own code. Inputs stay env vars — the contract the hooks already have. `team.yml` is untouched; CI keeps calling hooks directly.
- **The verb set is derived, never enumerated** — the directory listing at call time, minus the library and the dispatcher. A hand-kept roster of this package's own parts is the four-role-enumerations defect again (#37).
- **An unknown verb fails naming the known set** (E8 — failing loudly is not failing usefully).

**Tests** (`tests/test_run.py`): the derivation equals the directory; unknown verb exits 2 naming the set; a probe verb in a scratch dir proves env passthrough and exit-code passthrough without exercising any real hook.

**Rider**: fixes `App'''s` in the CHANGELOG — a shell-escaping artifact from #77, mine.

CHANGELOG: action required **no**. Not tagged, per the maintainer.

Gate: 212 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
