### PR TITLE
The CI root role bails: custodial work in full, conversation to the session

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -267,7 +267,7 @@ jobs:
       # is not "script or model", it is "read the issue or guess".
       - id: route-schema
         name: Load the routing schema
-        if: steps.route.outputs.defaulted == 'true' || steps.route.outputs.consult == 'true'
+        if: steps.route.outputs.defaulted == 'true'
         run: |
           # same constraints as the handoff and findings schemas: one line, and no single quote,
           # because it is inlined into a single-quoted claude_args flag
@@ -278,13 +278,13 @@ jobs:
           echo "body=$body" >> "$GITHUB_OUTPUT"
           echo "routing schema loaded (${#body} chars)"
       - id: route-prompt
-        if: steps.route.outputs.defaulted == 'true' || steps.route.outputs.consult == 'true'
+        if: steps.route.outputs.defaulted == 'true'
         uses: matt-whitaker/claude-team/.github/actions/load-prompt@mainline
         with:
           role: route
       - id: custodian
         name: Ask the root role which role this is
-        if: steps.route.outputs.defaulted == 'true' || steps.route.outputs.consult == 'true'
+        if: steps.route.outputs.defaulted == 'true'
         # ⚠️ A FAILED INTERCEPTION MUST NOT MEAN NOTHING RUNS. The script's default is the floor:
         # `resolve` falls back to it whenever this step produces no usable answer, and this keeps
         # the job green so it gets there. Degrading to the old behaviour is the correct failure.
@@ -435,11 +435,8 @@ jobs:
           REASON: ${{ steps.resolve.outputs.reason }}
           REMEDY: ${{ steps.resolve.outputs.remedy }}
           RESOLVED_BY: ${{ steps.resolve.outputs.resolved_by }}
-          # ⚠️ A consultation is not a gap. `defaulted` means state was missing and the issue needs
-          # fixing; `consult` means someone typed `@claude` and the only open question was whether
-          # they wanted words or work. Announcing every one of those would be noise, so the hook
-          # speaks only when the answer changed what runs.
-          CONSULT: ${{ steps.route.outputs.consult }}
+          # ⚠️ `consult` was removed with rule 1b's interception (epic #78): a bare mention now
+          # settles to the root role, which bails. Only `defaulted` reaches the interception.
           SCRIPT_ROLES: ${{ steps.route.outputs.roles }}
         run: "$RUNNER_TEMP/agent-bin/report-route.py"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 ## Unreleased
 
-**Action required:** no — nothing for an existing consumer.
+**Action required:** no — nothing to configure, but bare mentions behave differently.
+
+- **A bare `@claude` comment no longer answers or routes — the CI root role bails.** It does its
+  custodial work (repairs, stuck-task diagnosis) and otherwise replies that the fallback fired,
+  pointing the maintainer to a session. Rule 1b's consult is removed with it: nothing turns a
+  comment into a run any more except an explicit `@claude/<role>` handle. The label front door,
+  the cascade, and `defaulted`-route interception are untouched. (Epic #78, the session-driver
+  model.)
 
 - **`hooks/run.py` is one entry point for the deterministic verbs** — `--list` names them, an
   unknown verb fails naming the known set, and a verb runs its hook with the caller's env and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,17 @@ a real gap, worth announcing, carrying a remedy. `consult` means the script deci
 allows and the only open question is a judgement about a sentence. `report-route.py` stays **silent**
 on a consultation that changed nothing.
 
+⚠️ [E1] **SUPERSEDED (2026-08-24): THE CONSULT IS GONE, AND THE ROOT ROLE NOW BAILS.** The two
+paragraphs above shipped, worked, and were retired deliberately with epic #78: conversation moved
+to the **session driver**, and the CI root role became its fallback. A bare mention settles to
+`claude` deterministically — scripted again, which is where E1 wanted it — and the role does its
+custodial work in full, then replies only that the fallback fired, pointing the maintainer to a
+session. **A fallback that starts work turns a missed ping into a run nobody reviewed**, so the
+request-routing died with the consult: `@claude/<role>` is now the one way a comment invokes a
+runner. The interception machinery survives solely for `defaulted` routes. The paragraphs stay
+because their reasoning still binds — a regex cannot read a sentence, which is exactly why the
+judgement moved to a session rather than back into script.
+
 ⚠️ **This is not a role chaining off another**, which remains forbidden. The maintainer triggered the
 run; the router is deciding which role serves that trigger.
 
@@ -457,7 +468,7 @@ is a setup failure, so there is no result payload and `num_turns` cannot diagnos
 
 | role | picked up from | writes |
 |---|---|---|
-| `@claude` | its name in a **comment**, with no role handle; **and** a route the script had to guess | an answer, a role name, and repairs to process state. No code, no branch, no PR |
+| `@claude` | its name in a **comment**, with no role handle; **and** a route the script had to guess | repairs to process state, a role name on a guessed route, and otherwise a bail notice pointing to the session. No code, no branch, no PR |
 | Architect | an epic or an unshaped story | the issue, a story's branch name, and its tasks |
 | Researcher | a spike | findings and a recommendation, appended to the issue by a hook — it holds no shell |
 | Implementor | a task stamped `Role: implementor` | code, outside the design system |

--- a/hooks/delegate.py
+++ b/hooks/delegate.py
@@ -42,13 +42,11 @@ ROLES = STORY = STORY_BRANCH = REASON = KIND = REMEDY = ""
 DEFAULTED = False
 DISPATCH = False
 
-# ⚠️ CONSULT IS NOT DEFAULTED, AND CONFLATING THEM WOULD BE WRONG IN BOTH DIRECTIONS.
-# `defaulted` means the state that should have decided is MISSING — a real gap, worth announcing
-# and worth a remedy. `consult` means the script decided correctly as far as it can, but the
-# question it cannot answer is whether the maintainer wanted a conversation or wanted work. That
-# is a judgement, not a gap: there is nothing to fix on the issue, and announcing it every time
-# someone types `@claude` would be pure noise.
-CONSULT = False
+# ⚠️ `consult` USED TO LIVE HERE, AND ITS REMOVAL IS DELIBERATE (2026-08-24, epic #78). It was
+# rule 1b's "is this a question or a request" interception, distinct from `defaulted` (missing
+# state, a real gap, still consulted). The comment path no longer asks: a bare mention settles to
+# the root role, which acts custodially and BAILS with a notice — the session is where the
+# conversation happens. Do not reintroduce a consult here without reading the epic first.
 
 
 def emit() -> None:
@@ -67,7 +65,7 @@ def emit() -> None:
         with open(out, "a", encoding="utf-8") as handle:
             handle.write(
                 f"roles={ROLES}\nstory={STORY}\nstory_branch={STORY_BRANCH}\nkind={KIND}\n"
-                f"defaulted={str(DEFAULTED).lower()}\nconsult={str(CONSULT).lower()}\n"
+                f"defaulted={str(DEFAULTED).lower()}\n"
                 f"dispatch={str(DISPATCH).lower()}\n"
                 f"reason={REASON}\nremedy={REMEDY}\n"
             )
@@ -164,42 +162,27 @@ for role in ("architect", "researcher", "implementor", "tester", "writer", "desi
         emit()
         raise SystemExit(0)
 
-# ---- 1b. a bare `@claude` in a COMMENT is a conversation, not a route
+# ---- 1b. a bare `@claude` in a COMMENT settles to the root role, which bails
 #
-# ⚠️ COMMENT ONLY. The `@claude` **label** still routes exactly as it always has — that is the
-# front door and nothing here touches it. The split is worth stating plainly because it is the
-# whole ergonomics of the change: **the label does the work, a comment talks about it.**
+# ⚠️ COMMENT ONLY. The `@claude` **label** is the front door and routes untouched by this rule:
+# the label does the work, a comment talks about it.
 #
-# Reaching here means rule 1 found no `@claude/<role>` handle, so the trigger named `@claude`
-# and nothing more. Previously that fell through to rules 2-4 and started whichever role the
-# state implied — so typing "@claude what happened here?" ran an Implementor. Nothing is lost by
-# ending it: `@claude/<role>` still names a role outright, and re-adding the label is the
-# documented "run again" gesture.
+# Reaching here means rule 1 found no `@claude/<role>` handle. The route is deterministic:
+# `claude`, the CI fallback. Its prompt bounds what runs there — custodial work in full, a bail
+# notice for everything else. Conversation belongs to the session driver (epic #78); a comment
+# invokes a runner only through an explicit `@claude/<role>` handle. ⚠️ Do not add a model
+# consultation here — the interception serves `defaulted` routes only, and CLAUDE.md's routing
+# section carries the record of the consult this replaced.
 #
-# ⚠️ An unknown handle lands here too (`@claude/nonsense` matches no role), and that is the right
-# home for it — the root role can say there is no such role, where rule 3 would have silently
-# shaped the issue as a story instead.
+# An unknown handle (`@claude/nonsense`) lands here too; the root role says there is no such
+# role.
 #
-# ⚠️ AND IT ASKS RATHER THAN ASSUMING, because "a bare @claude is a question" is true most of the
-# time and expensively wrong the rest. Measured: a maintainer commented "@claude I believe this
-# branch needs to be updated from its base" — a request for WORK. The script had a clear
-# path straight to the conversational role, so the delegate-phase custodian never ran, and the
-# role that answered was structurally unable to do anything about it. The path was clear and
-# wrong, which no amount of scripted state can detect: only reading the sentence tells you.
-#
-# So this sets `consult`, not a settled route. The custodian in the delegate phase decides
-# question-or-work BEFORE the role jobs gate on the answer — which is the only point at which
-# the decision can still change what runs. `claude` remains the fallback, so a failed, skipped or
-# undecided interception lands exactly where this rule used to send it outright.
-#
-# ⚠️ EXCEPT ON A TASK, WHERE THERE IS NO QUESTION TO ASK. A task reached by a bare `@claude` is
-# presumed STUCK — its runs happen from its story, so a human landing on the task itself is
-# there because something did not happen. That is the Custodian's job (diagnose, repair,
-# report), and it is decidable from structure: a task's Branch line names another issue's
-# branch. Deterministic, so no consultation — the Delegator is for judgement, not for facts.
+# ⚠️ EXCEPT ON A TASK: a task reached by a bare `@claude` is presumed STUCK — its runs happen
+# from its story, so a human landing on the task itself is there because something did not
+# happen. The Custodian diagnoses. Decidable from structure: a task's Branch line names another
+# issue's branch.
 if COMMENT_BODY and "@claude" in COMMENT_BODY:
     ROLES = "claude"
-    REASON = "@claude named in a comment with no role handle — asking whether this is a question or work"
     # the same context a handle gets: being conversational is no reason to arrive uninformed
     if NUMBER:
         if IS_PR:
@@ -213,7 +196,7 @@ if COMMENT_BODY and "@claude" in COMMENT_BODY:
             "rather than re-running it"
         )
     else:
-        CONSULT = True
+        REASON = "@claude named in a comment with no role handle — the CI fallback answers custodially and bails"
     emit()
     raise SystemExit(0)
 

--- a/hooks/report-route.py
+++ b/hooks/report-route.py
@@ -39,32 +39,11 @@ MARKER = "<!-- claude-team:routing-guess -->"
 if not team.REPO:
     team.fail("REPO is required")
 
-CONSULT = os.environ.get("CONSULT", "") == "true"
 SCRIPT_ROLES = os.environ.get("SCRIPT_ROLES", "")
 
-if not (NUMBER and ROLES) or not (DEFAULTED or CONSULT):
-    raise SystemExit(0)
-
-# ⚠️ A CONSULTATION IS NOT A GAP, AND MOST OF THEM DESERVE SILENCE. `defaulted` means the state
-# that should have decided is missing — worth announcing, and it carries a remedy. `consult` means
-# somebody typed `@claude` and the only open question was whether they wanted words or work. When
-# the answer is "words", the run does exactly what it would have done anyway and there is nothing
-# to report; announcing it every time would make this notice the thing people skim past.
-#
-# ⚠️ But when a consultation CHANGES the route, say so — that is the maintainer asking for one
-# thing and getting another, correctly, and they should not have to infer it from which job ran.
-if CONSULT and not DEFAULTED and ROLES == SCRIPT_ROLES:
-    print(f"consulted, and the route is unchanged ({ROLES}) — nothing to report.")
-    raise SystemExit(0)
-
-if CONSULT and not DEFAULTED:
-    team.upsert_comment(
-        NUMBER, MARKER,
-        f"{MARKER}\n🔔 **You asked `@claude`, and this reads as a request for work rather than a "
-        f"question — so it was routed to `{ROLES}` instead of being answered.** {REASON}\n\n"
-        f"If you wanted an answer rather than the work, say so and it will not route again."
-        + team.run_footer(),
-    )
+# Only a `defaulted` route is reported — the real gap, carrying a remedy. A bare mention
+# settles to the root role, which bails (epic #78); nothing to report there.
+if not (NUMBER and ROLES) or not DEFAULTED:
     raise SystemExit(0)
 
 if RESOLVED_BY == "custodian":

--- a/prompts/claude.md
+++ b/prompts/claude.md
@@ -1,8 +1,20 @@
-You are **`@claude`** — the root role. Someone named you in a comment and wants an answer, not a
-run.
+You are **`@claude`** — the root role. Someone named you in a comment, and this run reaching you
+means the mention landed on the CI fallback.
 
-Every other role here is triggered to *produce* something: code, tests, a specification, a shaped
-issue. You are the one they talk to.
+⚠️ **You are the fallback, not the conversation** (epic #78). The maintainer's conversation
+happens in a live session, which holds the context you do not: memory, history with this work,
+standing plans. A mention reaching CI means no session has taken it. Hold the fort, visibly, and
+hand the thread back:
+
+- **Do the custodial half in full.** Process repairs, diagnosing a stuck task, correcting board
+  and label state — everything in your repair remit proceeds exactly as before.
+- **Bail on the rest, gracefully and by name.** For a question, a request for work, a discussion:
+  do not attempt the full answer, do not name a role to run, and never start anything. Reply
+  briefly — restate what was asked in one line, say plainly that this reached the CI fallback and
+  no session claimed it, and that the maintainer should raise it in a session to resolve. One
+  short comment; the notice IS the deliverable.
+- ⚠️ **Never quietly do the work instead**: an answer produced here lacks the context the
+  maintainer routes on, and the missed relay goes unreported — the notice is the signal.
 
 ## Why you exist
 

--- a/prompts/route.md
+++ b/prompts/route.md
@@ -25,17 +25,16 @@ script cannot: what the issue actually describes.
 - `$STORY` — the story this belongs to, where one could be resolved. Often empty here, and that
   emptiness is itself a signal.
 
-## The three ways you get here
+## The two ways you get here
 
 - **A task with no `Role:` stamp.** The Architect writes it; an issue filed by hand has none. The
   body still says what the work is, and that is what you read.
 - **A story that was triggered instead of one of its tasks.** It has sub-issues and no stamp of its
   own. Nothing should run on it directly.
-- **Somebody wrote a bare `@claude` in a comment** — on a story or a PR. ⚠️ A bare `@claude` on a
-  **task** never reaches you: a task is presumed stuck and routes to the Custodian by structure,
-  not judgement. **This one is different from the other two: nothing is missing.** The script knows exactly where it would send this — to you, conversationally
-  — and the only thing it cannot read is whether the maintainer wanted an ANSWER or wanted WORK.
-  That is a sentence to be read, not a state to be looked up.
+
+⚠️ **A bare `@claude` in a comment never reaches you**: it settles to the root role, which acts
+custodially and bails to the session (epic #78). Arriving here on a comment path means routing
+is wrong — say so rather than picking a role.
 
 ## How to decide
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -46,5 +46,29 @@ class Delegate(HookCase):
         self.assertIn("story=746", self.line(r))
 
 
+
+    # ---- rule 1b: a bare mention settles to the root role, which bails (epic #78) ----
+
+    def test_bare_mention_settles_to_the_root_role(self):
+        r = self.route("1092", STORY_WITH_KIDS, comment="@claude what happened here?",
+                       event="issue_comment", label="")
+        self.assertIn("roles=claude", self.line(r))
+        self.assertNotIn("consult", r.outputs, "delegate emits no consult output")
+        self.assertIn("bails", self.line(r))
+
+    def test_bare_mention_on_a_task_routes_to_the_custodian_diagnosis(self):
+        r = self.route("1093", TASK, comment="@claude", event="issue_comment", label="")
+        self.assertIn("roles=claude", self.line(r))
+        self.assertIn("presumed stuck", self.line(r))
+
+    def test_a_work_request_in_a_comment_reaches_no_working_role(self):
+        r = self.route("1092", STORY_WITH_KIDS,
+                       comment="@claude I believe this branch needs to be updated from its base",
+                       event="issue_comment", label="")
+        self.assertIn("roles=claude", self.line(r))
+        self.assertEqual(r.outputs.get("dispatch"), "false",
+                         "a comment must never start a wave")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Story 6's CI half, from epic [#78](https://github.com/matt-whitaker/claude-team/issues/78).

**Behavior**: a bare `@claude` comment settles to the root role deterministically. The role does its custodial remit in full — repairs, stuck-task diagnosis, board and label state — and for anything else replies once: the fallback fired, no session claimed it, raise it in a session. A comment invokes a runner only through an explicit `@claude/<role>` handle.

**Changes**:

- `hooks/delegate.py` — rule 1b settles to `claude`; no `consult` output
- `.github/workflows/team.yml` — the three interception gates read `defaulted` alone
- `hooks/report-route.py` — reports `defaulted` routes only
- `prompts/claude.md` — the fallback remit, first section
- `prompts/route.md` — serves `defaulted` routes only
- `CLAUDE.md` — routing section records the supersession in place; roles table updated
- `tests/test_delegate.py` — three 1b tests: bare mention settles and bails, a work-request comment reaches no working role, task → Custodian diagnosis

**Unchanged**: the label front door, the cascade, `defaulted`-route interception, the Custodian task diagnosis.

CHANGELOG: action required no — nothing to configure; bare mentions behave as above.

Gate: 215 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
