### PR TITLE
Dark means no dispatch: allowed_bots gates the cascade, not the secrets

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -463,6 +463,7 @@ jobs:
           REPO: ${{ github.repository }}
           STORY: ${{ steps.route.outputs.story }}
           HAVE_SECRETS: ${{ secrets.DISPATCH_APP_ID != '' && secrets.DISPATCH_APP_PRIVATE_KEY != '' }}
+          ALLOWED_BOTS: ${{ inputs.allowed_bots }}
         run: "$RUNNER_TEMP/agent-bin/dispatch-next.py"
 
       # ⚠️ THE ROUTING STEP WAS THE ONLY MODEL STEP HERE SHIPPING NO TRANSCRIPT, which is why #807
@@ -660,6 +661,7 @@ jobs:
           REPO: ${{ github.repository }}
           STORY: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
           HAVE_SECRETS: ${{ secrets.DISPATCH_APP_ID != '' && secrets.DISPATCH_APP_PRIVATE_KEY != '' }}
+          ALLOWED_BOTS: ${{ inputs.allowed_bots }}
         run: "$RUNNER_TEMP/agent-bin/dispatch-next.py"
 
       # ⚠️ AFTER file-sub-issues, which is what makes the children discoverable — this places
@@ -1763,6 +1765,7 @@ jobs:
           REPO: ${{ github.repository }}
           STORY: ${{ needs.delegate.outputs.story }}
           HAVE_SECRETS: ${{ secrets.DISPATCH_APP_ID != '' && secrets.DISPATCH_APP_PRIVATE_KEY != '' }}
+          ALLOWED_BOTS: ${{ inputs.allowed_bots }}
         run: "$RUNNER_TEMP/agent-bin/dispatch-next.py"
 
       # ⚠️ The primary call site. After each landing the hook checks whether that was the LAST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 **Action required:** no — nothing to configure, but bare mentions behave differently.
 
+- **A dark cascade no longer dispatches.** `allowed_bots: ""` now stops `dispatch-next.py`
+  outright, whatever the App secrets say — previously a dark repo with secrets set dispatched a
+  run that died at the actor guard after consuming the front-door label, blocking the real
+  driver (#82). Consumers admitting a bot are unchanged.
+
 - **A bare `@claude` comment no longer answers or routes — the CI root role bails.** It does its
   custodial work (repairs, stuck-task diagnosis) and otherwise replies that the fallback fired,
   pointing the maintainer to a session. Rule 1b's consult is removed with it: nothing turns a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,6 +454,16 @@ it.
 - ⚠️ A stale front-door label on an open issue is a **hand-removal** — removing it re-arms the issue
   as dispatchable, which is why no sweep does it automatically.
 
+⚠️ [E7] **DISPATCH IS GATED BY THE DRIVER DECLARATION, AND FOR A WHILE IT READ A PROXY.**
+`dispatch-next.py` gated on token mintability, so a consumer with App secrets set and
+`allowed_bots: ""` — a declared human or session driver — still dispatched. The run died at the
+host action's actor guard as designed, but the dead dispatch had already consumed the front-door
+label, so the real driver's own add was a silent no-op. Measured twice in one story
+(fantasy-football #84, issue #82): both inter-wave transitions raced, both recovered only by the
+hand-remove/re-add gesture. An empty `allowed_bots` now stops dispatch outright, same quiet
+notice as no secrets; the loud error stays reserved for admitted-bots-but-no-token, the one shape
+a human must fix.
+
 ⚠️ **Guard the loop.** Every stamp is another `labeled` event. Gate the trigger on the label name
 being *exactly* the front-door label, and exclude bot actors. Both hold independently, and a third
 comes free: a stamp applied with `GITHUB_TOKEN` starts no run.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -83,9 +83,10 @@ Settle these before touching files; each is a judgment call about the target, no
   and *what is the App named right now*. ⚠️ Ask for the name even if you think you know it —
   Apps get renamed, the slug is the identity, and a stub admitting a stale slug refuses every
   cascaded run at setup with *"Workflow initiated by non-human actor"*. The answer `""` is the
-  explicit decision to start **dark**: a finished task will not dispatch the next one, and the
-  maintainer's label gesture drives everything — a valid starting state, since the cascade is an
-  upgrade, not a prerequisite. ⚠️ The slug only *admits* the App: the cascade also needs the App
+  explicit decision to start **dark**: no dispatch fires whatever the secrets say, and the
+  driver's label gesture — the maintainer's, or a session driving the story — advances each
+  wave. A valid starting state, since the cascade is an upgrade, not a prerequisite. ⚠️ The slug
+  both *admits* the App at the model steps and *arms* dispatch; the cascade also needs the App
   installed on the repository and its secrets set (step 6). ⚠️ Name the App, never `*`: a
   wildcard admits any App on GitHub.
 - **`node`** — `true` if any author needs a runtime to install or build with; a repo whose gate

--- a/hooks/dispatch-next.py
+++ b/hooks/dispatch-next.py
@@ -38,6 +38,25 @@ import team
 
 STORY = os.environ.get("STORY", "")
 HAVE_SECRETS = os.environ.get("HAVE_SECRETS", "").lower() == "true"
+ALLOWED_BOTS = os.environ.get("ALLOWED_BOTS", "").strip()
+
+# ⚠️ [E7] THE DRIVER DECLARATION GATES DISPATCH, NOT THE SECRETS. Gating on token mintability read
+# a proxy: secrets present meant "cascade wanted", and it does not — a consumer with the App
+# secrets set and `allowed_bots: ""` has declared a HUMAN or SESSION driver. This hook then
+# dispatched anyway, the run died at the host action's actor guard (the bot is not admitted), and
+# the dead dispatch had already consumed the front-door label — so the real driver's own label add
+# became a silent no-op. Measured twice in one story, fantasy-football #84 (issue #82): both
+# inter-wave transitions raced, both runs died in ~2s, both waves needed a hand re-arm.
+# An empty allowed_bots is the same configured-off state as no secrets, and stays the same quiet
+# notice. The loud error remains reserved for secrets-present-bots-admitted-no-token, which is
+# still the only shape a human must fix.
+if not ALLOWED_BOTS:
+    print(
+        "::notice::cascade dark — no bot is admitted (`allowed_bots` is empty). The next task is "
+        "the driver's to label: the maintainer's gesture, or a session driving the story. This is "
+        "the configured-off state, not a failure."
+    )
+    raise SystemExit(0)
 
 # ⚠️ THE MISSING TOKEN IS DIAGNOSED HERE, NOT GATED AWAY IN THE WORKFLOW. The dispatch step used
 # to require a non-empty token in its `if:`, so a mint that FAILED produced a silently skipped

--- a/tests/test_dispatch_next.py
+++ b/tests/test_dispatch_next.py
@@ -18,7 +18,7 @@ def issues(body, tasks, labelled=()):
 
 class DispatchNext(HookCase):
     def dispatch(self, body, tasks, labelled=(), extra=None):
-        env = {"STORY": "10", "GH_TOKEN": "t",
+        env = {"STORY": "10", "GH_TOKEN": "t", "ALLOWED_BOTS": "some-bot",
                "STUB_ISSUES": issues(body, tasks, labelled)}
         env.update(extra or {})
         return self.run_hook("dispatch-next.py", env)
@@ -53,12 +53,23 @@ class DispatchNext(HookCase):
         data = issues("x", [{"number": 11, "state": "open"}])
         data["11"]["labels"] = ["@claude/complete"]
         r = self.run_hook("dispatch-next.py",
-                          {"STORY": "10", "GH_TOKEN": "t", "STUB_ISSUES": data})
+                          {"STORY": "10", "GH_TOKEN": "t", "ALLOWED_BOTS": "some-bot",
+                           "STUB_ISSUES": data})
         self.assertEqual(self.dispatched(r), ["11"])
+
+    def test_dark_declaration_stops_dispatch_even_with_secrets_and_token(self):
+        """#82, measured twice on fantasy-football #84: secrets present, token mintable, and the
+        consumer declared no bot — dispatch must not fire, or the dead run eats the label the
+        real driver needs."""
+        r = self.dispatch(BODY_WAVES, TASKS4, extra={"ALLOWED_BOTS": "", "HAVE_SECRETS": "true"})
+        self.assertEqual(self.dispatched(r), [], "a dark repo must add no labels")
+        self.assertIn("cascade dark", r.stdout)
+        self.assertIn("notice", r.stdout, "declared-off is quiet, never an error")
 
     def test_secrets_present_but_no_token_is_loud(self):
         r = self.run_hook("dispatch-next.py",
-                          {"STORY": "10", "HAVE_SECRETS": "true", "GH_TOKEN": ""})
+                          {"STORY": "10", "HAVE_SECRETS": "true", "GH_TOKEN": "",
+                           "ALLOWED_BOTS": "some-bot"})
         self.assertIn("::error::", r.stdout)
         self.assertIn("not INSTALLED", r.stdout)
 
@@ -77,7 +88,8 @@ HEADING_LINE = "**Sequencing.** Its tasks run in order: #11, then #12, then #14.
 class InertSequencing(HookCase):
     def dispatch(self, body, tasks=TASKS4):
         return self.run_hook("dispatch-next.py", {
-            "STORY": "10", "GH_TOKEN": "t", "STUB_ISSUES": issues(body, tasks)})
+            "STORY": "10", "GH_TOKEN": "t", "ALLOWED_BOTS": "some-bot",
+            "STUB_ISSUES": issues(body, tasks)})
 
     def dispatched(self, r):
         return [c["args"][1].split("/")[-2] for c in self.calls_matching(r, "labels")]


### PR DESCRIPTION
Fixes [#82](https://github.com/matt-whitaker/claude-team/issues/82).

**The defect**: `dispatch-next.py` gated on token mintability — a proxy. A consumer with App secrets set and `allowed_bots: ""` has declared a human or session driver; the hook dispatched anyway, the run died at the actor guard, and the dead dispatch had already **consumed the front-door label**, making the real driver's add a silent no-op. Measured twice in one story (fantasy-football #84, the session-driven pilot).

**The fix**: an empty `allowed_bots` exits before minting — the same quiet `::notice::` as the no-secrets state, because both are the configured-off state. The loud `::error::` stays reserved for admitted-bots-but-no-token, the one shape a human must fix. The declaration reaches the hook as `ALLOWED_BOTS` at all three call sites.

**Also**: ONBOARDING's dark description now says what dark does; CLAUDE.md records the defect in the cascade section (tagged E7 — a fact read from a proxy instead of its holder); CHANGELOG entry, action required no.

**Test**: secrets and token present, declaration empty → zero labels added, notice emitted. Plus the existing suites re-based on an admitted-bot env.

Gate: 216 tests, OK.

After merge, the `take-on-story` precondition ("check `allowed_bots`") is correct as originally written — the caveat from the pilot report dissolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
