### PR TITLE
Ship law and procedure for consumers' .claude/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 ## Unreleased
 
-**Action required:** no — nothing to configure, but bare mentions behave differently.
+**Action required:** yes, to adopt the new layer — one copy step per consumer; nothing breaks
+without it.
+
+- **claude-team now ships law and procedure for consumers' `.claude/`.** `templates/settings/`
+  is a settings fragment plus `guard-push.py` — harness-enforced: no default-branch push, no
+  force-push, no `gh pr merge`, from any session in the repo. `skills/` ships `shape-story` and
+  `diagnose-run`. Install is a verbatim copy (ONBOARDING §3); re-copying is the upgrade. A
+  committed skill or hook is maintainer-owned law — reviewed merge is the governance, per the
+  epic #78 drills.
 
 - **A dark cascade no longer dispatches.** `allowed_bots: ""` now stops `dispatch-next.py`
   outright, whatever the App secrets say — previously a dark repo with secrets set dispatched a

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -56,6 +56,8 @@ Then, in order:
 
 5. **Re-run everything the pin cannot carry — unconditionally, every time.** It is idempotent and
    cheap, and this is the half a version number can never express:
+   - **The `.claude/` install** — re-copy the settings fragment, guard, and skills from §3;
+     like the labels, no ref bump has ever touched a consumer's committed copies.
    - **§4's label loop.** ⚠️ Labels live in GitHub, not in the clone, so no ref bump has ever
      touched them. It is the one step already written to be idempotent and it still drifted,
      because nothing told anyone to re-run it.
@@ -152,6 +154,29 @@ weight: [`claude-team-example`](https://github.com/matt-whitaker/claude-team-exa
 annotated for an audience), `brewdocs.beer-kb` (a research-led data repo: its Researcher overlay
 redefines findings as file/field/current/proposed/source), `brewdocs.beer` (a full application).
 Nothing in the base prompts names any repo — if an overlay only restates the base, delete it.
+
+### The law and the skills — `.claude/`
+
+Two more installs land beside the overlay, both copied verbatim from this repo and both
+**maintainer-owned law once committed** (a skill's frontmatter can grant tools past a session
+allowlist, and a settings hook executes on whatever machine opens the repo — reviewed merge is
+the entire governance):
+
+```bash
+mkdir -p .claude/hooks .claude/skills
+cp <claude-team>/templates/settings/settings.json .claude/settings.json
+cp <claude-team>/templates/settings/hooks/guard-push.py .claude/hooks/
+cp -R <claude-team>/skills/* .claude/skills/
+```
+
+- **The settings fragment + `guard-push.py`** are harness-enforced: no push to the default
+  branch, no force-push, no `gh pr merge`, from any session in this repo — the same rules the
+  prompts state, made law (E17). ⚠️ A repo that already has a `.claude/settings.json` merges the
+  `hooks` block by hand; the fragment is the reference, and this install must not clobber.
+- **The skills** (`shape-story`, `diagnose-run`) are procedure — discoverable by any session and
+  by CI runs. claude-harness ships the session-conduct skills separately; these are the
+  backlog's.
+- Re-copying is the upgrade, like the label loop: idempotent, and drift is a diff away.
 
 ## 4. The labels
 

--- a/skills/diagnose-run/SKILL.md
+++ b/skills/diagnose-run/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: diagnose-run
+description: Read a claude-team workflow run the way its record says runs must be read — by jobs, steps, and fingerprints, never the tracking comment. Use when a run failed, a task stalled, a cascade went quiet, or a result looks wrong in any repo running claude-team.
+argument-hint: [run id or task ref]
+---
+
+The tracking comment looks identical in success and death, and `gh run list --limit 1` happily
+hands you the wrong run. Resolve the run from the task (`gh run list` matched on the task ref),
+then read **jobs → failing step → that step's log**.
+
+## The fingerprints
+
+Match before theorizing — each of these was measured, and each points at a different fix:
+
+- **Dies in ~3s, no result payload, before the model** — a setup failure. The two commonest:
+  the actor guard (*"Workflow initiated by non-human actor"* — a bot actor the stub's
+  `allowed_bots` does not admit; on a rename, a stale slug) and a missing base branch (404 in
+  `setupBranch` — the story's named ref does not exist yet).
+- **Run reports success, task did nothing** — the dead-run shape. `num_turns` small, seconds of
+  model time: check `trigger_phrase` extraction (a handle swallowed as a slash command) and the
+  backgrounding stall (a tidy checklist, boxes unticked).
+- **Model step failed at env validation in seconds** — the OAuth token is missing or lapsed.
+  Everything scripted still ran; only the model half is dark.
+- **Every step green, next task never started** — read the dispatch step's notice: dark cascade
+  (declared off — the driver labels by hand) is a `::notice::`; admitted-bots-but-no-token is an
+  `::error::` and means the App is not installed on the repository.
+- **Task closed but no handoff on the story** — distinguish three states: entries, explicit
+  `[]`, and **absent**. Absent means no author ran or it died before posting: re-trigger, do not
+  close by hand.
+- **`Resource not accessible by integration` at setup** — the job needs `pull-requests: write`
+  for its tracking comment on a PR trigger; the permission checked is not `issues`.
+
+## Conduct
+
+- The full transcript exists on every run (`claude-execution-output.json` via the
+  `execution_file` output) — collect it before the runner ages out; treat it as secret material.
+- A finding against landed work is an ad-hoc commit on the story branch or a **new task** —
+  a landed task never reopens.
+- The same failure twice on the same task is a stop-and-report, not a third trigger — repeating
+  the re-trigger suppresses the signal.
+- Fix and report, never fix quietly: the diagnosis goes on the issue where the next reader
+  finds it, not in the void of a job log.

--- a/skills/shape-story/SKILL.md
+++ b/skills/shape-story/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: shape-story
+description: File a claude-team story with its tasks in the exact shapes the hooks parse — Branch line, Role stamps, Sequencing contract, sub-issue parenting. Use when shaping backlog work by hand or from a session, in any repo running claude-team.
+argument-hint: [what the story delivers]
+---
+
+You are doing by hand what the Architect role does in CI, and the hooks cannot tell the
+difference — which means the shapes must be exact. `team.branch_line()` and `team.role_stamp()`
+are the parsers; when in doubt, verify a body against them rather than against your memory.
+
+## The story
+
+1. Create the story issue first — its number names the branch. Body opens with:
+
+   ```
+   **Branch: `<story#>-<kebab-summary>`**
+   ```
+
+   Do not create the branch; the first author run's upsert makes the name real.
+2. Outcome, boundaries, acceptance criteria — what a careful colleague needs, no more. State
+   what is out of scope. An unmeetable criterion is a defect: no issue may require a role to
+   spend its whole budget.
+3. **Does a specification need writing before the code?** Yes → the story divides and a
+   `Role: writer` task is cut first. No → a story one author can finish is stamped as-is:
+   `**Role: <role>**` beside its Branch line, no tasks, done here.
+
+## The tasks
+
+Each task's body opens with exactly two lines:
+
+```
+**Branch: `<the story's branch>`**
+**Role: <implementor|designer|tester|writer>**
+```
+
+The Branch line names the *story's* branch — that is what makes it a task. One deliverable per
+task; the tester derives from the spec and story, never the implementation.
+
+## Wire it
+
+1. Append the contract to the story body:
+
+   ```
+   ### Sequencing
+   1. #<first task>
+   2. #<next>
+   ```
+
+   Numbered lines, one wave per line. Prefer single-task waves — parallel tasks race on shared
+   files.
+2. **Parent every task to the story via the sub-issues API** — hand-filed issues are never
+   auto-parented (`file-sub-issues.py` trusts bot authors only):
+
+   ```
+   gh api -X POST repos/<owner>/<repo>/issues/<story#>/sub_issues -F sub_issue_id=<task node id>
+   ```
+
+3. Create everything **unlabeled**. The front-door label is the trigger, applied by whoever
+   drives — labeling is starting, not filing.
+
+## Verify before handing over
+
+From a claude-team checkout: every task's first lines parse (`team.branch_line`,
+`team.role_stamp` — role non-empty, branch equal to the story's), the story's own branch line
+leads with its issue number, and the sub-issue count matches the task count. A shape the parsers
+reject is invisible to every hook downstream.

--- a/templates/settings/hooks/guard-push.py
+++ b/templates/settings/hooks/guard-push.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""PreToolUse guard: no push to the default branch, no force-push, no merge — from any driver.
+
+Installed into a consumer's `.claude/hooks/` beside the settings fragment that wires it. The
+harness runs it before every Bash tool call; exit 2 blocks the call and the message on stderr
+reaches the model. Stdlib only, no network — a guard that can fail on a fetch is a guard that
+gets skipped.
+
+⚠️ This is law, not procedure: the same rules exist as prompt instructions, and the record of
+this package is that instructions get skipped (E17). The guard is what makes "never push the
+default branch" true of a session the way the workflow's permissions make it true of CI.
+
+⚠️ Token-match, never substring: a branch named `42-mainline-fix` must not trip the `mainline`
+rule. Push targets are compared as whole refs after splitting refspecs on `:`.
+"""
+import json
+import re
+import sys
+
+DEFAULT_BRANCHES = {"mainline", "main", "master"}
+
+
+def deny(reason: str) -> None:
+    print(reason, file=sys.stderr)
+    sys.exit(2)
+
+
+def main() -> None:
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # not our shape; never block on our own parse failure
+    command = (event.get("tool_input") or {}).get("command") or ""
+    if not command:
+        sys.exit(0)
+
+    # Normalise: examine each simple command in a compound line.
+    for part in re.split(r"(?:&&|\|\||;|\|)", command):
+        tokens = part.strip().split()
+        if not tokens:
+            continue
+
+        if "git" in tokens[:2] and "push" in tokens:
+            rest = tokens[tokens.index("push") + 1:]
+            if any(t in ("--force", "-f") or t.startswith("--force-with-lease") for t in rest):
+                deny("guard-push: force-push is blocked here — reconcile by merge, or hand the "
+                     "conflict to the maintainer. (claude-team guard)")
+            for t in rest:
+                if t.startswith("-"):
+                    continue
+                # a refspec pushes to its right-hand side; a bare ref pushes to itself
+                target = t.split(":")[-1]
+                if target.removeprefix("refs/heads/") in DEFAULT_BRANCHES:
+                    deny(f"guard-push: pushing to '{target}' is blocked — the default branch "
+                         "changes by merged PR only. Push a branch and open the PR. "
+                         "(claude-team guard)")
+
+        if "gh" in tokens[:1] and "pr" in tokens and "merge" in tokens:
+            deny("guard-push: merging is the maintainer's — open or update the PR and hand over "
+                 "the link. (claude-team guard)")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/settings/settings.json
+++ b/templates/settings/settings.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "claude-team's harness-enforced law, installed as the consumer's .claude/settings.json alongside .claude/hooks/. A repo with its own settings.json merges the hooks block by hand — this file is the reference. The guard blocks default-branch pushes, force-pushes, and PR merges from any session; the same rules exist as prompt instructions, and the guard is what makes them enforcement (E17).",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guard-push.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_ship.py
+++ b/tests/test_ship.py
@@ -1,0 +1,99 @@
+"""The shipped consumer artifacts: the guard blocks what it claims, and only that.
+
+`templates/settings/` is installed into a consumer's `.claude/` — it is law executed by the
+harness on every Bash call, in every session, in that repo. A guard that blocks too little is a
+prompt instruction wearing enforcement's clothes; one that blocks too much starves the driver.
+Both directions are asserted, with the near-miss cases (a branch *named* like a default branch)
+that a substring match would get wrong.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+GUARD = ROOT / "templates/settings/hooks/guard-push.py"
+SETTINGS = ROOT / "templates/settings/settings.json"
+SKILLS = sorted((ROOT / "skills").glob("*/SKILL.md"))
+
+
+def run_guard(command: str):
+    event = {"tool_name": "Bash", "tool_input": {"command": command}}
+    return subprocess.run([sys.executable, str(GUARD)], input=json.dumps(event),
+                          capture_output=True, text=True)
+
+
+class GuardPush(unittest.TestCase):
+    def assert_blocked(self, command, why=""):
+        r = run_guard(command)
+        self.assertEqual(r.returncode, 2, f"{command!r} must be blocked {why}: {r.stderr}")
+        self.assertIn("guard-push:", r.stderr)
+
+    def assert_allowed(self, command, why=""):
+        r = run_guard(command)
+        self.assertEqual(r.returncode, 0, f"{command!r} must be allowed {why}: {r.stderr}")
+
+    def test_default_branch_pushes_are_blocked(self):
+        self.assert_blocked("git push origin mainline")
+        self.assert_blocked("git push origin main")
+        self.assert_blocked("git push -u origin master")
+        self.assert_blocked("git push origin HEAD:mainline", "a refspec's target is the push")
+        self.assert_blocked("git push origin feature:refs/heads/main")
+
+    def test_force_push_is_blocked_anywhere(self):
+        self.assert_blocked("git push --force origin feature-x")
+        self.assert_blocked("git push -f origin feature-x")
+        self.assert_blocked("git push --force-with-lease origin feature-x")
+
+    def test_merging_is_blocked(self):
+        self.assert_blocked("gh pr merge 42 --squash")
+
+    def test_ordinary_work_is_untouched(self):
+        self.assert_allowed("git push origin the-heartbeat")
+        self.assert_allowed("git push -u origin 84-brief-screen")
+        self.assert_allowed("git push origin 42-mainline-fix",
+                            "a branch NAMED like a default must not trip a token match")
+        self.assert_allowed("git fetch origin mainline", "fetching the default is reading")
+        self.assert_allowed("gh pr view 42")
+        self.assert_allowed("ls -la")
+
+    def test_compound_commands_are_examined_per_segment(self):
+        self.assert_blocked("git add -A && git commit -m x && git push origin mainline")
+
+    def test_malformed_input_never_blocks(self):
+        r = subprocess.run([sys.executable, str(GUARD)], input="not json",
+                           capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0,
+                         "the guard must fail open on its own parse errors — a guard that "
+                         "blocks on malformed input blocks everything when the harness "
+                         "changes its event shape")
+
+
+class ShippedArtifacts(unittest.TestCase):
+    def test_settings_fragment_is_valid_and_wires_the_shipped_guard(self):
+        d = json.loads(SETTINGS.read_text(encoding="utf-8"))
+        commands = [h["command"]
+                    for m in d["hooks"]["PreToolUse"] for h in m["hooks"]]
+        self.assertTrue(any("guard-push.py" in c for c in commands),
+                        "the fragment must wire the guard this directory ships")
+        for c in commands:
+            name = c.split("/")[-1].strip('"')
+            self.assertTrue((GUARD.parent / name).exists(),
+                            f"fragment references {name}, which templates/settings/hooks does "
+                            "not ship — a wired-but-absent hook fails every Bash call")
+
+    def test_guard_compiles_alone(self):
+        r = subprocess.run([sys.executable, "-m", "py_compile", str(GUARD)],
+                           capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_every_skill_carries_name_and_description(self):
+        self.assertTrue(SKILLS, "skills/ ships at least one skill")
+        for p in SKILLS:
+            head = p.read_text(encoding="utf-8").split("---")[1]
+            self.assertRegex(head, r"(?m)^name: \S+", p.name)
+            self.assertRegex(head, r"(?m)^description: \S+", p.name)


### PR DESCRIPTION
Story 4 of epic [#78](https://github.com/matt-whitaker/claude-team/issues/78), first slice: claude-team ships **law** and **procedure** for consumers' `.claude/`, installed by verbatim copy like the label canon.

**`templates/settings/` — the law.** A settings fragment wiring `guard-push.py` as a PreToolUse hook, harness-enforced in every session in the repo:

- no push to the default branch (`mainline`/`main`/`master`, token-matched — `42-mainline-fix` passes)
- no force-push anywhere
- no `gh pr merge` — merging is the maintainer's

Grounded in drill 1b: hooks fire headless, block allowlisted calls, and the model can't skip them. The guard **fails open on its own parse errors** — a guard that blocks on malformed input blocks everything the day the harness changes its event shape.

**`skills/` — the procedure.** `shape-story` (the exact shapes the hooks parse, ending in verify-against-`team.py`) and `diagnose-run` (the fingerprint catalog as a read order). Session-conduct skills stay in claude-harness per the split.

**Deliberately not in this slice**: `Skill(name)` grants in role allowlists (a grant with no prompt consuming it is a dead channel — lands with the prompt slimming), the Stop-hook deliverable check (needs design), settings-merge tooling (no fleet repo has its own settings.json; the fragment documents hand-merge).

**Install**: ONBOARDING §3 gains the copy step; §0.5's re-run list gains it (no ref bump touches committed copies). CHANGELOG: action required **yes** to adopt, nothing breaks without it. Governance per drill 1a: a committed skill or hook is maintainer-owned law; reviewed merge is the whole control.

**Tests** (`tests/test_ship.py`, 9): both directions of the guard including the near-misses, fragment-wires-only-shipped-files, skill frontmatter. Gate: 225 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
