### PR TITLE
Sync the .claude/ installs (law,rule)

### DIFF
--- a/.claude/hooks/guard-push.py
+++ b/.claude/hooks/guard-push.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""PreToolUse guard: no push to the default branch, no force-push, no merge — from any driver.
+
+Installed into a consumer's `.claude/hooks/` beside the settings fragment that wires it. The
+harness runs it before every Bash tool call; exit 2 blocks the call and the message on stderr
+reaches the model. Stdlib only, no network — a guard that can fail on a fetch is a guard that
+gets skipped.
+
+⚠️ This is law, not procedure: the same rules exist as prompt instructions, and the record of
+this package is that instructions get skipped (E17). The guard is what makes "never push the
+default branch" true of a session the way the workflow's permissions make it true of CI.
+
+⚠️ Token-match, never substring: a branch named `42-mainline-fix` must not trip the `mainline`
+rule. Push targets are compared as whole refs after splitting refspecs on `:`.
+"""
+import json
+import re
+import sys
+
+DEFAULT_BRANCHES = {"mainline", "main", "master"}
+
+
+def deny(reason: str) -> None:
+    print(reason, file=sys.stderr)
+    sys.exit(2)
+
+
+def main() -> None:
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # not our shape; never block on our own parse failure
+    command = (event.get("tool_input") or {}).get("command") or ""
+    if not command:
+        sys.exit(0)
+
+    # Normalise: examine each simple command in a compound line.
+    for part in re.split(r"(?:&&|\|\||;|\|)", command):
+        tokens = part.strip().split()
+        if not tokens:
+            continue
+
+        if "git" in tokens[:2] and "push" in tokens:
+            rest = tokens[tokens.index("push") + 1:]
+            if any(t in ("--force", "-f") or t.startswith("--force-with-lease") for t in rest):
+                deny("guard-push: force-push is blocked here — reconcile by merge, or hand the "
+                     "conflict to the maintainer. (claude-team guard)")
+            for t in rest:
+                if t.startswith("-"):
+                    continue
+                # a refspec pushes to its right-hand side; a bare ref pushes to itself
+                target = t.split(":")[-1]
+                if target.removeprefix("refs/heads/") in DEFAULT_BRANCHES:
+                    deny(f"guard-push: pushing to '{target}' is blocked — the default branch "
+                         "changes by merged PR only. Push a branch and open the PR. "
+                         "(claude-team guard)")
+
+        if "gh" in tokens[:1] and "pr" in tokens and "merge" in tokens:
+            deny("guard-push: merging is the maintainer's — open or update the PR and hand over "
+                 "the link. (claude-team guard)")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/rules/claude-harness.md
+++ b/.claude/rules/claude-harness.md
@@ -1,6 +1,6 @@
 # claude-harness
 
-**harness-rule-revision: 11** · from `matt-whitaker/claude-harness`
+**harness-rule-revision: 12** · from `matt-whitaker/claude-harness`
 
 ⚠️ **This file is entirely claude-harness's.** Nothing repo-specific goes in it. To upgrade,
 **replace it** — never merge. To uninstall, delete it.
@@ -154,6 +154,16 @@ what the backlog does; this section is only how the session conducts itself whil
   story and continues. If the last posted state is stale, that IS the diagnostic.
 - **The endgame is verified, not assumed.** After the last task closes, confirm the story's PR
   exists and says what landed; a missing PR is a diagnosis to run, never a silence to leave.
+- ⚠️ **A parked watcher is not a plan; arm a heartbeat beside it.** A watcher dies with its
+  session, and a dead driver halts a story silently. On taking a story, also arm a scheduled
+  re-check on a long interval (the watcher is the wake path; the heartbeat is the net). Each
+  heartbeat tick is the same move as any wake: reconcile the story from GitHub, advance what
+  moved, re-park what died. Driving several stories is one tick sweeping all of them, not one
+  heartbeat each.
+- **Resume is the heartbeat's move from zero.** A fresh session handed a mid-flight story reads
+  the posted state and continues; nothing about the previous driver's death needs diagnosing
+  first. What makes this work is the posting discipline above — protect it before optimizing
+  anything else.
 - ⚠️ **A driver never edits its own law mid-story.** Rules, skills, hooks, prompts — proposing a
   change is fine; landing one while driving under it is not.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "claude-team's harness-enforced law, installed as the consumer's .claude/settings.json alongside .claude/hooks/. A repo with its own settings.json merges the hooks block by hand — this file is the reference. The guard blocks default-branch pushes, force-pushes, and PR merges from any session; the same rules exist as prompt instructions, and the guard is what makes them enforcement (E17).",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guard-push.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/diagnose-run/SKILL.md
+++ b/.claude/skills/diagnose-run/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: diagnose-run
+description: Read a claude-team workflow run the way its record says runs must be read — by jobs, steps, and fingerprints, never the tracking comment. Use when a run failed, a task stalled, a cascade went quiet, or a result looks wrong in any repo running claude-team.
+argument-hint: [run id or task ref]
+---
+
+The tracking comment looks identical in success and death, and `gh run list --limit 1` happily
+hands you the wrong run. Resolve the run from the task (`gh run list` matched on the task ref),
+then read **jobs → failing step → that step's log**.
+
+## The fingerprints
+
+Match before theorizing — each of these was measured, and each points at a different fix:
+
+- **Dies in ~3s, no result payload, before the model** — a setup failure. The two commonest:
+  the actor guard (*"Workflow initiated by non-human actor"* — a bot actor the stub's
+  `allowed_bots` does not admit; on a rename, a stale slug) and a missing base branch (404 in
+  `setupBranch` — the story's named ref does not exist yet).
+- **Run reports success, task did nothing** — the dead-run shape. `num_turns` small, seconds of
+  model time: check `trigger_phrase` extraction (a handle swallowed as a slash command) and the
+  backgrounding stall (a tidy checklist, boxes unticked).
+- **Model step failed at env validation in seconds** — the OAuth token is missing or lapsed.
+  Everything scripted still ran; only the model half is dark.
+- **Every step green, next task never started** — read the dispatch step's notice: dark cascade
+  (declared off — the driver labels by hand) is a `::notice::`; admitted-bots-but-no-token is an
+  `::error::` and means the App is not installed on the repository.
+- **Task closed but no handoff on the story** — distinguish three states: entries, explicit
+  `[]`, and **absent**. Absent means no author ran or it died before posting: re-trigger, do not
+  close by hand.
+- **`Resource not accessible by integration` at setup** — the job needs `pull-requests: write`
+  for its tracking comment on a PR trigger; the permission checked is not `issues`.
+
+## Conduct
+
+- The full transcript exists on every run (`claude-execution-output.json` via the
+  `execution_file` output) — collect it before the runner ages out; treat it as secret material.
+- A finding against landed work is an ad-hoc commit on the story branch or a **new task** —
+  a landed task never reopens.
+- The same failure twice on the same task is a stop-and-report, not a third trigger — repeating
+  the re-trigger suppresses the signal.
+- Fix and report, never fix quietly: the diagnosis goes on the issue where the next reader
+  finds it, not in the void of a job log.

--- a/.claude/skills/shape-story/SKILL.md
+++ b/.claude/skills/shape-story/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: shape-story
+description: File a claude-team story with its tasks in the exact shapes the hooks parse — Branch line, Role stamps, Sequencing contract, sub-issue parenting. Use when shaping backlog work by hand or from a session, in any repo running claude-team.
+argument-hint: [what the story delivers]
+---
+
+You are doing by hand what the Architect role does in CI, and the hooks cannot tell the
+difference — which means the shapes must be exact. `team.branch_line()` and `team.role_stamp()`
+are the parsers; when in doubt, verify a body against them rather than against your memory.
+
+## The story
+
+1. Create the story issue first — its number names the branch. Body opens with:
+
+   ```
+   **Branch: `<story#>-<kebab-summary>`**
+   ```
+
+   Do not create the branch; the first author run's upsert makes the name real.
+2. Outcome, boundaries, acceptance criteria — what a careful colleague needs, no more. State
+   what is out of scope. An unmeetable criterion is a defect: no issue may require a role to
+   spend its whole budget.
+3. **Does a specification need writing before the code?** Yes → the story divides and a
+   `Role: writer` task is cut first. No → a story one author can finish is stamped as-is:
+   `**Role: <role>**` beside its Branch line, no tasks, done here.
+
+## The tasks
+
+Each task's body opens with exactly two lines:
+
+```
+**Branch: `<the story's branch>`**
+**Role: <implementor|designer|tester|writer>**
+```
+
+The Branch line names the *story's* branch — that is what makes it a task. One deliverable per
+task; the tester derives from the spec and story, never the implementation.
+
+## Wire it
+
+1. Append the contract to the story body:
+
+   ```
+   ### Sequencing
+   1. #<first task>
+   2. #<next>
+   ```
+
+   Numbered lines, one wave per line. Prefer single-task waves — parallel tasks race on shared
+   files.
+2. **Parent every task to the story via the sub-issues API** — hand-filed issues are never
+   auto-parented (`file-sub-issues.py` trusts bot authors only):
+
+   ```
+   gh api -X POST repos/<owner>/<repo>/issues/<story#>/sub_issues -F sub_issue_id=<task node id>
+   ```
+
+3. Create everything **unlabeled**. The front-door label is the trigger, applied by whoever
+   drives — labeling is starting, not filing.
+
+## Verify before handing over
+
+From a claude-team checkout: every task's first lines parse (`team.branch_line`,
+`team.role_stamp` — role non-empty, branch equal to the story's), the story's own branch line
+leads with its issue number, and the sub-issue count matches the task count. A shape the parsers
+reject is invisible to every hook downstream.


### PR DESCRIPTION
Verbatim copies, per the installs' own upgrade convention. **Law** from claude-team `fd59a80` — the guard (live-verified in the canary repo) + `shape-story`/`diagnose-run`. **Rule** revision **11 → 12** — the driving heartbeat. Touches only `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)