### PR TITLE
Verify real parentage before the closed-trigger opens a story PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 ## Unreleased
 
 **Action required:** yes, to adopt the new layer — one copy step per consumer; nothing breaks
+
+- **The closed-trigger PR-opener verifies real parentage.** open-story-pr.py now checks the
+  closed issue'''s actual parent matches the story its Branch line names, before opening a PR. The
+  trigger is reachable by any issue author; the Branch line is attacker-controllable body text,
+  the parent link is not. Ceiling was a premature PR, never code execution. No consumer action.
 without it.
 
 - **claude-team now ships law and procedure for consumers' `.claude/`.** `templates/settings/`

--- a/hooks/open-story-pr.py
+++ b/hooks/open-story-pr.py
@@ -55,6 +55,21 @@ if not BASE and ISSUE:
             f"{named or 'nothing'}. Nothing to open."
         )
         raise SystemExit(0)
+    # ⚠️ [E2] THE BRANCH LINE IS A CLAIM, NOT PROOF OF PARENTAGE. On a public repo the author of
+    # an issue can close their own with no collaborator rights, so this trigger is reachable by
+    # anyone — and the Branch line is body text they control. An issue whose line names a real
+    # story's branch would otherwise open that story's PR early. The parent link is state only the
+    # machinery (or a maintainer) can set, so verify the claimed story is the ACTUAL parent before
+    # acting on the claim. The ceiling without this is a premature PR, not code execution — the job
+    # holds no model step and `contents: read` — but a claim checked against a settable fact is the
+    # anti-pattern this package already names.
+    if team.parent(ISSUE) != owner:
+        print(
+            f"#{ISSUE}'s Branch line names story #{owner}, but its actual parent is "
+            f"{team.parent(ISSUE) or 'none'} — the claim does not match the hierarchy. "
+            "Nothing to open."
+        )
+        raise SystemExit(0)
     BASE = named
     print(f"#{ISSUE} closed by hand; checking its story's branch `{BASE}`.")
 

--- a/tests/test_open_story_pr.py
+++ b/tests/test_open_story_pr.py
@@ -97,7 +97,8 @@ class AHandClosedTaskCanStillOpenTheStoryPR(HookCase):
     nothing ran. Third story in that repo to need its PR opened by hand."""
 
     TASK = {
-        "45": {"body": "Branch: `43-give-story-and-task-colours`\nRole: implementor"},
+        "45": {"body": "Branch: `43-give-story-and-task-colours`\nRole: implementor",
+               "parent": "43"},
         "43": {
             "title": "Give story and task their own colours",
             "kids": [{"number": 45, "title": "Recolour", "state": "closed"}],
@@ -146,6 +147,22 @@ class AHandClosedTaskCanStillOpenTheStoryPR(HookCase):
         self.assertEqual(r.returncode, 0)
         self.assertIn("not a task", r.stdout)
         self.assertFalse(self.calls_matching(r, "pr", "create"))
+
+    def test_a_branch_line_that_is_not_the_real_parent_opens_nothing(self):
+        """⚠️ #83: this trigger is reachable by anyone who can close an issue (its own author, on
+        a public repo), and the Branch line is body text they control. A crafted line naming a
+        real story's branch must not open that story's PR — the parent link is the settable-only
+        fact that gates it."""
+        crafted = {
+            "45": {"body": "Branch: `43-give-story-and-task-colours`", "parent": "999"},
+            "43": {"title": "Real story",
+                   "kids": [{"number": 44, "title": "the real task", "state": "closed"}]},
+        }
+        r = self.closed(issues=crafted)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("does not match the hierarchy", r.stdout)
+        self.assertFalse(self.calls_matching(r, "pr", "create"),
+                         "a claim not backed by real parentage must open nothing")
 
     def test_an_issue_with_no_branch_line_opens_nothing(self):
         """⚠️ Written negatively — "not a story, so proceed" — an unresolvable issue would open


### PR DESCRIPTION
Fixes [fantasy-football#83](https://github.com/matt-whitaker/fantasy-football/issues/83).

The `issues:closed` trigger is reachable by any issue author (closing one's own issue needs no collaborator rights on a public repo), and `open-story-pr.py` resolved the story from the closed issue's **Branch line — attacker-controllable body text**. A crafted line naming a real story's branch opened that story's PR early.

**Fix**: the hook verifies `team.parent(ISSUE)` matches the story the Branch line names. The parent link is settable only by the machinery or a maintainer, so the claim is checked against a fact the attacker cannot set (E2).

**Ceiling this closed**: a premature PR — the `task_closed` job holds no model step and `contents: read`, so never code execution or secret exposure. Real but low-severity.

New test drives the craft path (Branch line names #43, real parent #999 → opens nothing) and is mutation-checked: disabling the guard fails it. Gate: 226 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
