### PR TITLE
A driver switch, defaulting to session; the App cascade is opt-in

### DIFF
--- a/.github/actions/dispatch-next/action.yml
+++ b/.github/actions/dispatch-next/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: The consumer's `allowed_bots` input, verbatim. Empty means dark — the hook exits with a notice and adds no label.
     required: false
     default: ''
+  driver:
+    description: '`cascade` opts this repo into the App cascade (auto-dispatch on). Any other value (default) means session-driven — the cascade stands down and dispatches nothing.'
+    required: false
+    default: ''
   app-id:
     description: The dispatch App id (secret), or empty.
     required: false
@@ -45,7 +49,7 @@ runs:
   steps:
     - name: Mint the dispatch token
       id: mint
-      if: inputs.enabled == 'true'
+      if: inputs.enabled == 'true' && inputs.driver == 'cascade'
       continue-on-error: true
       uses: actions/create-github-app-token@v2
       with:
@@ -60,4 +64,5 @@ runs:
         STORY: ${{ inputs.story }}
         HAVE_SECRETS: ${{ inputs.app-id != '' && inputs.private-key != '' }}
         ALLOWED_BOTS: ${{ inputs.allowed_bots }}
+        DRIVER: ${{ inputs.driver }}
       run: "$RUNNER_TEMP/agent-bin/dispatch-next.py"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,6 +70,8 @@ jobs:
       project_owner: matt-whitaker
       project_number: "9"
       allowed_bots: ""
+      # The driver switch — session-driven by default; set CLAUDE_TEAM_DRIVER to `cascade` to opt in.
+      driver: ${{ vars.CLAUDE_TEAM_DRIVER }}
       node: false
       browser: false
       # ⚠️ This repo is stdlib Python and its gate is `python3 -m unittest`. It is also

--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -131,6 +131,10 @@ on:
         description: Comma-separated bot logins admitted at the model steps (the dispatch App). Empty admits none.
         type: string
         default: ""
+      driver:
+        description: '`cascade` opts into the App cascade (auto-dispatch). The default is session-driven — a session advances the waves and the cascade stands down. A consumer wires this to a repo variable so it toggles in the UI without a PR.'
+        type: string
+        default: ""
       node:
         description: Set up Node with npm cache and run npm ci before author runs
         type: boolean
@@ -455,6 +459,7 @@ jobs:
           story: ${{ steps.route.outputs.story }}
           repo: ${{ github.repository }}
           allowed_bots: ${{ inputs.allowed_bots }}
+          driver: ${{ inputs.driver }}
           app-id: ${{ secrets.DISPATCH_APP_ID }}
           private-key: ${{ secrets.DISPATCH_APP_PRIVATE_KEY }}
 
@@ -645,6 +650,7 @@ jobs:
           story: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
           repo: ${{ github.repository }}
           allowed_bots: ${{ inputs.allowed_bots }}
+          driver: ${{ inputs.driver }}
           app-id: ${{ secrets.DISPATCH_APP_ID }}
           private-key: ${{ secrets.DISPATCH_APP_PRIVATE_KEY }}
 
@@ -1741,6 +1747,7 @@ jobs:
           story: ${{ needs.delegate.outputs.story }}
           repo: ${{ github.repository }}
           allowed_bots: ${{ inputs.allowed_bots }}
+          driver: ${{ inputs.driver }}
           app-id: ${{ secrets.DISPATCH_APP_ID }}
           private-key: ${{ secrets.DISPATCH_APP_PRIVATE_KEY }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,17 @@ The upgrade procedure itself is [`ONBOARDING.md` §0](ONBOARDING.md).
 
 ## Unreleased
 
-**Action required:** yes, to adopt the new layer — one copy step per consumer; nothing breaks
+**Action required:** yes for App-driven repos — set `CLAUDE_TEAM_DRIVER` to `cascade` to keep the cascade; session-driven repos need nothing.
+
+- ⚠️ **The default driver is now the SESSION; the App cascade is opt-in. App-driven repos must
+  act.** A `driver` input decides who advances a story's waves. Its default — and the default of
+  the repo variable `CLAUDE_TEAM_DRIVER` it is wired to — is **session-driven**: a human or a
+  `take-on-story` session labels each wave, and **nothing auto-dispatches**. A repo that wants the
+  App cascade sets `CLAUDE_TEAM_DRIVER` to `cascade` (Settings → Variables, no PR). **A repo that
+  relied on the cascade and does nothing will go quiet** — its next task will not start itself.
+  Set the variable to `cascade` to restore it. `allowed_bots` alone no longer turns the cascade
+  on; the cascade needs both `driver: cascade` and a bot admitted. The safe default was the point:
+  auto-dispatch starts runs unattended, so a misconfiguration now suppresses it rather than firing.
 
 - **The cascade is one composite action, not three inline copies.** `dispatch-next` (mint token +
   run the hook) was copy-pasted into the delegate, architect and authors jobs; it is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,11 +290,16 @@ story's PR, with every task's diff accumulated. A `push:` trigger restores it an
 ## How a story moves
 
 ⚠️ **TWO DRIVERS ADVANCE A STORY ACROSS ITS TASKS, AND THE CONSUMER DECLARES WHICH.** A wave ends
-when a task closes; something then labels the next wave. That something is either the **App
-cascade** (`allowed_bots` names a bot — `dispatch-next.py` mints a token and adds the label) or a
-**human/session driver** (`allowed_bots: ""` — the maintainer's gesture, or a session running
-`take-on-story`, adds it). Neither is the default: the empty `allowed_bots` is as deliberate a
-choice as a named one, and `dispatch-next.py` exits quietly on it. The cascade lives in one place,
+when a task closes; something then labels the next wave. That something is a **session by default** (the maintainer's gesture, or a session running
+`take-on-story`, labels each wave) — the **App cascade** is opt-in. ⚠️ **The `driver` input is the
+switch, the default is the session, and it is meant to be a repo variable.** Auto-dispatch is what
+starts runs unattended, so it is the opt-in half: `driver: cascade` turns it on (and needs the App
+installed, its secrets set and its bot in `allowed_bots`); anything else — unset, `session`, a typo
+— is session-driven, dispatching nothing. That default is the safe one: a misconfiguration
+suppresses auto-dispatch rather than starting runs nobody asked for. ⚠️ `allowed_bots` is a separate
+control — the actor-guard admission list — and the cascade needs both it and `driver: cascade`;
+neither alone starts it. A consumer wires `driver: ${{ vars.CLAUDE_TEAM_DRIVER }}`, so the toggle is
+a variable in the UI, not a PR. The cascade lives in one place,
 the `dispatch-next` composite action, called at the three sites a wave can start; the rest of the
 workflow is driver-agnostic — it routes and runs one role whoever labelled the trigger.
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -100,6 +100,13 @@ Settle these before touching files; each is a judgment call about the target, no
   builds nothing, so the first *author* run is where this surfaces.
 - **`browser`** — `true` only if authors must drive a running app to verify their work. Every
   author run then pays a chromium download, so a data or docs repo says `false`.
+- **`driver`** — the drive switch, wired to a variable rather than hard-set:
+  `driver: ${{ vars.CLAUDE_TEAM_DRIVER }}`. **The default is session-driven** — a human or a
+  session labels each wave, and nothing auto-dispatches. To turn on the App cascade, set the repo
+  variable `CLAUDE_TEAM_DRIVER` to `cascade` in *Settings → Variables* (no PR); that also needs the
+  dispatch App installed with its secrets, and its slug in `allowed_bots`. Leave the input wired
+  even for a session-driven repo — an unset variable is session, and the wiring is what makes the
+  switch a UI toggle rather than a code change later.
 
 ## 2. The stub
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ not happen, never as a failure.
 | `node` | no | your call — `true` runs `npm ci` before author runs |
 | `browser` | no | your call — `true` installs the Playwright chromium |
 | `runtimes` | no | **your repo's gate** — the commands an author must be able to run. Defaults to `npm,npx,node` |
+| `driver` | no | **the drive switch** — `cascade` opts into auto-dispatch; the default is session-driven (a session advances the waves). Wire it to a repo variable to toggle in the UI |
 
 ⚠️ Name the App in `allowed_bots` **explicitly**. A wildcard lets any external App invoke the
 action with a prompt it controls.
@@ -110,6 +111,18 @@ action with a prompt it controls.
 `bundle`, and so on. Each entry becomes a `Bash(<name>:*)` grant for the four authoring roles, and
 they hold no other runtime. An author that cannot run your gate still produces the change; it just
 cannot verify it, and says so in its report rather than failing — which is easy to miss.
+
+⚠️ **`driver` is the drive switch, and the default is the session.** A story advances across its
+tasks by one of two drivers: a **session** (the default — a human or a `take-on-story` session
+labels each wave) or the **App cascade** (opt-in — `dispatch-next.py` labels the next wave when a
+task closes). Auto-dispatch is the thing that starts runs on its own, so it is not the default: a
+repo turns it on with `driver: cascade`, which also needs the App installed, its secrets set and its
+bot in `allowed_bots`. Any other value — unset, `session`, a typo — is session-driven, so a
+misconfiguration suppresses auto-dispatch rather than starting runs nobody asked for. Wire it to a
+variable — `driver: ${{ vars.CLAUDE_TEAM_DRIVER }}` in your stub — and flip
+`CLAUDE_TEAM_DRIVER` to `cascade` in *Settings → Secrets and variables → Actions → Variables* with
+no PR. `allowed_bots` is separate: it is the actor-guard admission list, and the cascade needs both
+it and `driver: cascade`.
 
 ### Secrets — *Settings → Secrets and variables → Actions*
 

--- a/hooks/dispatch-next.py
+++ b/hooks/dispatch-next.py
@@ -39,6 +39,23 @@ import team
 STORY = os.environ.get("STORY", "")
 HAVE_SECRETS = os.environ.get("HAVE_SECRETS", "").lower() == "true"
 ALLOWED_BOTS = os.environ.get("ALLOWED_BOTS", "").strip()
+DRIVER = os.environ.get("DRIVER", "").strip().lower()
+
+# ⚠️ THE DEFAULT DRIVER IS THE SESSION, AND THE CASCADE IS OPT-IN. Auto-dispatch is the thing with
+# a blast radius — it starts runs on its own — so it is not the default: a repo drives by session
+# (a human or a `take-on-story` session labels each wave) unless it explicitly asks for the App
+# cascade with `driver: cascade`. A repo variable carries the choice, flipped in the UI. Any value
+# that is not `cascade` — unset, empty, `session`, a typo — means session, which is the safe
+# outcome: a misconfiguration suppresses auto-dispatch rather than starting runs nobody asked for.
+# Checked FIRST, because it overrides everything below — a session driving does not care whether a
+# token could be minted.
+if DRIVER != "cascade":
+    print(
+        "::notice::dispatch suppressed — this repo is session-driven, the default. A session "
+        "advances the waves; the App cascade is opt-in. Set the driver variable to `cascade` to "
+        "turn on auto-dispatch."
+    )
+    raise SystemExit(0)
 
 # ⚠️ [E7] THE DRIVER DECLARATION GATES DISPATCH, NOT THE SECRETS. Gating on token mintability read
 # a proxy: secrets present meant "cascade wanted", and it does not — a consumer with the App
@@ -52,9 +69,9 @@ ALLOWED_BOTS = os.environ.get("ALLOWED_BOTS", "").strip()
 # still the only shape a human must fix.
 if not ALLOWED_BOTS:
     print(
-        "::notice::cascade dark — no bot is admitted (`allowed_bots` is empty). The next task is "
-        "the driver's to label: the maintainer's gesture, or a session driving the story. This is "
-        "the configured-off state, not a failure."
+        "::error::`driver: cascade` selected but `allowed_bots` is empty — no bot is admitted, so "
+        "a dispatched run would be rejected at the actor guard. Name the dispatch App's slug in "
+        "`allowed_bots`, or set the driver back to session."
     )
     raise SystemExit(0)
 

--- a/templates/consumer-stub.yml
+++ b/templates/consumer-stub.yml
@@ -57,6 +57,13 @@ jobs:
       project_owner: CHANGE-ME
       project_number: "0"
       allowed_bots: ""
+      # ⚠️ The DRIVER SWITCH, default session. Left as-is (variable unset) a SESSION advances the
+      # story's waves and nothing auto-dispatches. Set the repo variable CLAUDE_TEAM_DRIVER to
+      # `cascade` — in Settings → Secrets and variables → Actions → Variables, no PR — to opt into
+      # the App cascade; that also needs the App installed, its secrets set, and its slug in
+      # `allowed_bots` above. Flip the variable back to `session` (or clear it) to hand the repo
+      # to a session again.
+      driver: ${{ vars.CLAUDE_TEAM_DRIVER }}
       node: false
       browser: false
       # The commands an authoring role may run, so it can execute THIS repo's gate.

--- a/tests/test_dispatch_next.py
+++ b/tests/test_dispatch_next.py
@@ -18,7 +18,7 @@ def issues(body, tasks, labelled=()):
 
 class DispatchNext(HookCase):
     def dispatch(self, body, tasks, labelled=(), extra=None):
-        env = {"STORY": "10", "GH_TOKEN": "t", "ALLOWED_BOTS": "some-bot",
+        env = {"STORY": "10", "GH_TOKEN": "t", "ALLOWED_BOTS": "some-bot", "DRIVER": "cascade",
                "STUB_ISSUES": issues(body, tasks, labelled)}
         env.update(extra or {})
         return self.run_hook("dispatch-next.py", env)
@@ -54,22 +54,47 @@ class DispatchNext(HookCase):
         data["11"]["labels"] = ["@claude/complete"]
         r = self.run_hook("dispatch-next.py",
                           {"STORY": "10", "GH_TOKEN": "t", "ALLOWED_BOTS": "some-bot",
-                           "STUB_ISSUES": data})
+                           "DRIVER": "cascade", "STUB_ISSUES": data})
         self.assertEqual(self.dispatched(r), ["11"])
 
-    def test_dark_declaration_stops_dispatch_even_with_secrets_and_token(self):
-        """#82, measured twice on fantasy-football #84: secrets present, token mintable, and the
-        consumer declared no bot — dispatch must not fire, or the dead run eats the label the
-        real driver needs."""
-        r = self.dispatch(BODY_WAVES, TASKS4, extra={"ALLOWED_BOTS": "", "HAVE_SECRETS": "true"})
-        self.assertEqual(self.dispatched(r), [], "a dark repo must add no labels")
-        self.assertIn("cascade dark", r.stdout)
-        self.assertIn("notice", r.stdout, "declared-off is quiet, never an error")
+    def test_the_default_is_session_so_dispatch_is_suppressed(self):
+        """Session is the default: an unset driver stands the cascade down even with the App fully
+        configured — bot admitted, secrets present, token mintable. Nothing auto-dispatches unless
+        a repo opts into the cascade."""
+        r = self.dispatch(BODY_WAVES, TASKS4,
+                          extra={"ALLOWED_BOTS": "some-bot", "HAVE_SECRETS": "true", "DRIVER": ""})
+        self.assertEqual(self.dispatched(r), [], "the default adds no labels")
+        self.assertIn("session-driven, the default", r.stdout)
+        self.assertIn("notice", r.stdout, "the default is quiet, never an error")
+
+    def test_a_typo_in_the_driver_is_session_not_cascade(self):
+        """Any value that is not `cascade` is session — a misconfiguration suppresses auto-dispatch
+        rather than starting runs nobody asked for."""
+        r = self.dispatch(BODY_WAVES, TASKS4, extra={"ALLOWED_BOTS": "b", "DRIVER": "cascde"})
+        self.assertEqual(self.dispatched(r), [])
+
+    def test_cascade_is_opt_in_and_then_it_drives(self):
+        r = self.dispatch(BODY_WAVES, TASKS4,
+                          extra={"ALLOWED_BOTS": "some-bot", "DRIVER": "cascade"})
+        self.assertEqual(self.dispatched(r), ["12", "13"], "driver: cascade turns the cascade on")
+
+    def test_cascade_selected_with_no_bot_is_a_loud_error(self):
+        r = self.dispatch(BODY_WAVES, TASKS4, extra={"ALLOWED_BOTS": "", "DRIVER": "cascade"})
+        self.assertEqual(self.dispatched(r), [])
+        self.assertIn("::error::", r.stdout, "opted into the cascade with no bot admitted")
+
+    def test_cascade_opted_in_but_no_bot_admitted_adds_nothing(self):
+        """Opting into the cascade with an empty allowed_bots is a misconfiguration: a dispatched
+        run would be rejected at the actor guard, so the hook adds no label and says why loudly."""
+        r = self.dispatch(BODY_WAVES, TASKS4,
+                          extra={"ALLOWED_BOTS": "", "HAVE_SECRETS": "true", "DRIVER": "cascade"})
+        self.assertEqual(self.dispatched(r), [], "no bot admitted means no dispatch")
+        self.assertIn("::error::", r.stdout)
 
     def test_secrets_present_but_no_token_is_loud(self):
         r = self.run_hook("dispatch-next.py",
                           {"STORY": "10", "HAVE_SECRETS": "true", "GH_TOKEN": "",
-                           "ALLOWED_BOTS": "some-bot"})
+                           "ALLOWED_BOTS": "some-bot", "DRIVER": "cascade"})
         self.assertIn("::error::", r.stdout)
         self.assertIn("not INSTALLED", r.stdout)
 
@@ -88,7 +113,7 @@ HEADING_LINE = "**Sequencing.** Its tasks run in order: #11, then #12, then #14.
 class InertSequencing(HookCase):
     def dispatch(self, body, tasks=TASKS4):
         return self.run_hook("dispatch-next.py", {
-            "STORY": "10", "GH_TOKEN": "t", "ALLOWED_BOTS": "some-bot",
+            "STORY": "10", "GH_TOKEN": "t", "ALLOWED_BOTS": "some-bot", "DRIVER": "cascade",
             "STUB_ISSUES": issues(body, tasks)})
 
     def dispatched(self, r):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -151,7 +151,9 @@ class ReadmeDocumentsEveryInput(unittest.TestCase):
         root = pathlib.Path(__file__).resolve().parent.parent
         self.readme = (root / "README.md").read_text()
         self.secrets = set(re.findall(r"secrets\.([A-Z_]+)", TEAM)) - {"GITHUB_TOKEN"}
-        self.vars = set(re.findall(r"vars\.([A-Z_]+)", TEAM))
+        # A repo variable can be read in team.yml directly, or wired at the stub into an input —
+        # the driver switch is the latter, so both surfaces count as "the workflow reads it".
+        self.vars = set(re.findall(r"vars\.([A-Z_]+)", TEAM + STUB))
         self.inputs = set(re.findall(r"^      ([a-z_]+):$", TEAM.split("jobs:")[0], re.M))
         self.assertIn("## Inputs and secrets", self.readme, "the reference section is gone")
         self.section = self.readme.split("## Inputs and secrets")[1]


### PR DESCRIPTION
A story advances across its tasks by one of two drivers — a **session** or the **App cascade**. This makes the **session the default** and the cascade an explicit opt-in.

## Why session is the default

Auto-dispatch is the half with a blast radius: it starts runs unattended. So it isn't the default. A repo drives by session — a human or a `take-on-story` session labels each wave — unless it sets `driver: cascade`. `dispatch-next.py` suppresses dispatch for **any** value that isn't exactly `cascade` (unset, empty, `session`, a typo), so a misconfiguration suppresses auto-dispatch rather than starting runs nobody asked for. **The default is the safe one.**

| `CLAUDE_TEAM_DRIVER` | who drives |
|---|---|
| unset / `session` / anything else | **session (default)** — nothing auto-dispatches |
| `cascade` | the App cascade — needs the App installed, secrets, and a bot in `allowed_bots` |

The switch is a repo variable wired in the stub (`driver: ${{ vars.CLAUDE_TEAM_DRIVER }}`), so it flips in **Settings → Variables** with no PR. `allowed_bots` is separate — the actor-guard admission list — and the cascade needs both it and `driver: cascade`; the hook names the missing half loudly.

## ⚠️ Action required for App-driven repos

**A repo that relied on the cascade and does nothing after this goes quiet** — its next task won't start itself. Set `CLAUDE_TEAM_DRIVER` to `cascade` to restore it. Session-driven repos (`allowed_bots` empty today) need nothing.

In this fleet: **brewdocs.beer and brewdocs.beer-kb** are cascade-driven and track mainline — on merge they default to session until their variable is set to `cascade`. That's a UI toggle you make, and I'll flag it the moment this merges.

## Docs & tests

Inverted throughout — README table + paragraph (enforced by `ReadmeDocumentsEveryInput`), CLAUDE.md's two-driver section, ONBOARDING, stub comments, input/action descriptions. The README-vars test now scans the stub too, since a variable can be wired at the stub into an input. Tests inverted and mutation-checked: the default suppresses, a typo is session, cascade is opt-in and then drives, cascade-with-no-bot is a loud error. Gate: 234 OK.

## Where `driver` is documented (your earlier question)

README inputs table + paragraph · CLAUDE.md "How a story moves" · ONBOARDING §1 · the stub's inline comment · the input/action `description` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
