### PR TITLE
Release housekeeping for v4: roll the changelog, close a pin gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The upgrade procedure itself is [`INSTALL.md` §0](INSTALL.md).
 
 ## Unreleased
 
+**Action required:** n/a — nothing has landed since `v4`.
+
+## v4
+
 **Action required:** yes — App-driven repos set `CLAUDE_TEAM_DRIVER` to `cascade`; every consumer re-copies its `.claude/`, which now carries the session rule and skills as well.
 
 - ⚠️ **claude-harness is folded into claude-team; the session half now ships from one repo.** The session rule moves in as `rules/claude-session.md` (its own `session-rule-revision`, independent of the workflow pin), beside the existing `rules/claude-team.md`. The `handoff` and `take-on-story` skills move in too, and a new `upgrade-team` skill carries the upgrade flow. On upgrade, a consumer re-copies `.claude/rules/*` and `.claude/skills/*` from this repo. `ONBOARDING.md` is renamed `INSTALL.md`. The session rule arrives at `session-rule-revision: 13`, continuing the sequence it carried as `harness-rule-revision` — revisions 1–12 and their entries live in the retired repo's history, and everything they shipped is already installed fleet-wide.

--- a/rules/claude-team.md
+++ b/rules/claude-team.md
@@ -1,6 +1,6 @@
 # claude-team
 
-**team-ref: v2** · from `matt-whitaker/claude-team`
+**team-ref: mainline** · from `matt-whitaker/claude-team`
 
 ⚠️ **This file is entirely claude-team's.** Nothing repo-specific goes in it. To upgrade, **replace
 it** — never merge. To uninstall, delete it.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -10,6 +10,7 @@ TEAM = (ROOT / ".github/workflows/team.yml").read_text()
 WORKFLOW_AND_ACTIONS = TEAM + "\n".join(
     p.read_text() for p in sorted(ROOT.glob(".github/actions/*/action.yml")))
 ACTION = (pathlib.Path(__file__).resolve().parent.parent / ".github/actions/load-prompt/action.yml").read_text()
+RULE = (ROOT / "rules/claude-team.md").read_text()
 STUB = (pathlib.Path(__file__).resolve().parent.parent / "templates/consumer-stub.yml").read_text()
 SELF = (pathlib.Path(__file__).resolve().parent.parent / ".github/workflows/claude.yml").read_text()
 
@@ -621,6 +622,17 @@ class ReleasePins(unittest.TestCase):
         self.assertEqual(action_refs, {team_ref})
         self.assertEqual(prompt_default, team_ref)
         self.assertEqual(stub_ref, team_ref)
+
+    def test_the_rules_team_ref_moves_with_them(self):
+        """The rule ships a `team-ref` that a consumer must set to its pin, and the shipped value
+        is what an installer copies — so it is a pin like the others and drifts the same way. It
+        sat at an older release for two versions because only its SHAPE was asserted, never its
+        value against the rest."""
+        import re
+        team_ref, _, _, _ = self.refs()
+        rule_ref = re.search(r"\*\*team-ref: (\S+)\*\*", RULE).group(1)
+        self.assertEqual(rule_ref, team_ref,
+                         "rules/claude-team.md's team-ref must flip with every other pin")
 
 
 class SelfInstall(unittest.TestCase):


### PR DESCRIPTION
The **mergeable half** of the v4 release. Merge this, then cut the tag.

⚠️ **The pin flip is deliberately not in here.** CLAUDE.md keeps it on a commit that is *tagged and not merged*, so mainline keeps its `mainline` pins and the canaries stay canaries. This PR contains only what belongs on mainline permanently.

## What's in it

**1. The changelog rolls over.** The accumulated entries become `## v4`; a fresh `## Unreleased` opens above them. The suite asserts that heading always exists, because every PR writes its own entry into it.

**2. A pin gap closed — `rules/claude-team.md` said `team-ref: v2`.** Two releases stale, on a file an installer copies verbatim, so anyone installing from mainline took a wrong version stamp. It's a pin like the others and now reads `mainline` alongside them.

**3. `ReleasePins` now checks it.** The test asserted only that `team-ref` had a *shape*, never that its value matched the other pins — which is exactly how it drifted unnoticed. Now a release that flips the workflow refs and forgets the rule **fails before it ships**.

Gate: 240 OK.

## After merging — what the release commit must flip

**22 pins**, all currently `mainline`: `TEAM_REF`, the 18 `actions/*@mainline` refs in `team.yml`, `load-prompt`'s `default:`, `templates/consumer-stub.yml`'s `uses:`, **and now `rules/claude-team.md`'s `team-ref`** — `ReleasePins` verifies all of them agree.

`.github/workflows/claude.yml` (this repo's own stub) stays `mainline` — `SelfInstall` asserts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
