### PR TITLE
Lock every repo to a release; retire the canary model

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,16 +1,15 @@
 # claude-team CONSUMING ITSELF. The stub, frozen, exactly as templates/consumer-stub.yml ships it
 # — the only edits are the five inputs below and this note.
 #
-# ⚠️ THE `@ref` HERE IS PINNED TO `mainline` AND MUST STAY THERE. Every other consumer pins a
-# `vN` tag and bumps it in a one-line PR. This one cannot: release tooling flips the four pins it
-# knows about (TEAM_REF, the two composite-action refs, load-prompt's default, the template's) on a
-# commit that is tagged and DELIBERATELY NOT MERGED, so a `vN` written here would be a fifth pin
-# nothing asserts and nobody remembers — and mainline would run its own team on stale assets.
-# `SelfInstall` in tests/test_workflow.py asserts this file tracks `mainline` for that reason.
+# ⚠️ THE `@ref` HERE PINS A RELEASE, like every other consumer, and is bumped the same way: a
+# one-line PR after a tag exists. It is NOT one of the pins the release commit flips — those live
+# on a commit that is tagged and DELIBERATELY NOT MERGED, and this file lives on mainline.
+# `SelfInstall` in tests/test_workflow.py asserts it names a `vN`.
 #
-# ⚠️ A RUN HERE EXECUTES THE HOOKS AT `mainline`, NOT THE ONES IN THE CHECKOUT. Editing hooks/ on
-# a branch changes nothing about the run editing them; merging it changes the machinery for this
-# repo, for claude-team-example, and for every consumer tracking mainline at once.
+# ⚠️ A RUN HERE EXECUTES THE HOOKS AT THE PINNED TAG, NOT THE ONES IN THE CHECKOUT. Editing hooks/
+# on a branch changes nothing about the run editing them, and merging changes nothing here until
+# this pin is bumped — so a structural change is drilled in claude-team-example before a tag, not
+# discovered by this repo after one.
 # The whole consumer-side integration: this file, frozen, plus a .claude-team/ directory.
 # Triggers, run-name and concurrency live HERE — a called workflow's own run-name is ignored
 # and its workflow-level concurrency is unsupported.
@@ -65,7 +64,7 @@ jobs:
       pull-requests: write
       actions: read
       id-token: write
-    uses: matt-whitaker/claude-team/.github/workflows/team.yml@mainline
+    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v4
     with:
       project_owner: matt-whitaker
       project_number: "9"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ The upgrade procedure itself is [`INSTALL.md` §0](INSTALL.md).
 
 ## Unreleased
 
-**Action required:** n/a — nothing has landed since `v4`.
+**Action required:** no — a policy change in this repo; consumers already pin.
+
+- **Every repo pins a release; nothing tracks `@mainline`.** The canary model is retired: brewdocs.beer, claude-team-example and this repo's own stub pinned the edge so a bad change met real work before any pinned consumer saw it. All of them pin `@vN` now, and what a repo runs is answerable from its stub alone. ⚠️ The cost, accepted: nothing exercises the edge, so the suite and a drill in claude-team-example are all that stand between a merge and a release — drill a structural change **before** tagging. `SelfInstall` now asserts this repo's stub names a `vN`.
 
 ## v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,21 @@ say what is in `## Unreleased` that a consumer would want, and stop. ⚠️ It i
 gap to work around: a cloud session cannot push a tag at all, so the half it *can* do — a commit
 with the pins flipped — is the half that is dangerous on its own.
 
-⚠️ **Consumers pin `@vN`**; a repo whose job is to exercise the engine tracks `@mainline` instead —
-brewdocs.beer as the canary, `claude-team-example` as the drill target, and this repo's own stub,
-which `SelfInstall` pins there permanently. brewdocs.beer-kb also tracks `@mainline`, by the
-maintainer's call rather than by the rule. ⚠️ **A `vN` appearing anywhere on `mainline` is a
-defect** — the default branch is what the canaries run, so a pin flipped there stops it being one.
+⚠️ **Every repo pins `@vN`, this one included.** Nothing tracks `@mainline`: a consumer runs a
+released version and moves when its pin moves, which is what makes "what is this repo running"
+answerable from its stub alone. `SelfInstall` asserts this repo's own stub pins a release like any
+other consumer.
+
+⚠️ **The accepted cost is that nothing exercises the edge.** While a canary tracked `@mainline`, a
+bad change met real work before any pinned consumer saw it — that is how the dark-dispatch race and
+the composite-action question were caught. With every repo pinned, the suite and a drill in
+`claude-team-example` are the only things standing between a merge and a release. Drill a
+structural change before tagging, not after.
+
+⚠️ **The release commit still never merges.** Its pins are `vN`; mainline's stay `mainline`, so the
+next release flips from a clean base. A `vN` on mainline in `team.yml`, the actions, the template or
+`rules/claude-team.md` is still a defect — the exception is `.github/workflows/claude.yml`, this
+repo's own stub, which pins a release in an ordinary PR after the tag exists.
 
 ⚠️ **A release is not finished when the tag is pushed.** `INSTALL.md` §0 is the returning
 consumer's path and `CHANGELOG.md` is what makes it answerable. A consumer has one question — *must

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,8 +37,7 @@ Then, in order:
    only pin a consumer holds — `TEAM_REF` lives inside the workflow and moves with the tag, so a
    consumer never edits it and must never be told to. ⚠️ **Re-fetch `.claude/rules/claude-team.md` from the
    new ref** (§2) and check its `team-ref` matches: the two are one fact in two places, and a
-   mismatch is exactly the half-done upgrade nothing else can see. ⚠️ A repo that deliberately
-   tracks `@mainline` skips the bump; see the release note in `CLAUDE.md` for which ones and why.
+   mismatch is exactly the half-done upgrade nothing else can see.
 
 3. **Reconcile the stub — do not recreate it.** Diff it against
    [`templates/consumer-stub.yml`](templates/consumer-stub.yml). Everything but the header comment,
@@ -112,9 +111,9 @@ Settle these before touching files; each is a judgment call about the target, no
 
 Copy [`templates/consumer-stub.yml`](templates/consumer-stub.yml) to the target's
 `.github/workflows/claude.yml`, set the inputs, and **pin the `uses:` ref to the newest `vN`
-tag** (`git ls-remote --tags` here answers which). One repo in the fleet deliberately tracks
-`@mainline` to find breakage first; every other consumer pins, and picks up fixes by bumping
-the pin in a one-line PR when a release is cut.
+tag** (`git ls-remote --tags` here answers which). Every repo pins a release and picks up fixes by
+bumping the pin in a one-line PR when a new one is cut — nothing tracks `@mainline`, so what a repo
+runs is answerable from its stub alone.
 
 ⚠️ **Do not trim the `permissions:` block, even if the target seems not to need parts of it.**
 A called workflow cannot request permissions its caller didn't grant — the stub's block is the

--- a/skills/upgrade-team/SKILL.md
+++ b/skills/upgrade-team/SKILL.md
@@ -17,8 +17,6 @@ grep -o 'team\.yml@[^ ]*' <target>/.github/workflows/claude.yml   # installed
 git ls-remote --tags https://github.com/matt-whitaker/claude-team  # available
 ```
 
-A repo that deliberately tracks `@mainline` (a canary, a drill target) has no pin to bump — for it,
-"upgrade" is only the re-copy half below.
 
 ## The order (INSTALL.md §0 is the detail)
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -636,18 +636,21 @@ class ReleasePins(unittest.TestCase):
 
 
 class SelfInstall(unittest.TestCase):
-    """This repo consumes itself, and its stub is the ONE pin that must not move at release.
+    """This repo consumes itself, and its stub pins a release like every other consumer.
 
-    ReleasePins flips together on a release commit that is tagged and deliberately not merged.
-    `.github/workflows/claude.yml` lives on mainline permanently, so a `vN` written into it would
-    be a fifth pin nothing asserts — and mainline would run its own team on assets from an older
-    version of itself. A blanket mainline -> vN sweep across .github at release time is exactly
-    the plausible edit this catches."""
+    ⚠️ The stub is NOT one of ReleasePins' pins. Those flip on the release commit, which is tagged
+    and never merged; this file lives on mainline, so its pin moves in an ordinary PR after a tag
+    exists — the same bump every consumer makes.
 
-    def test_the_self_install_tracks_mainline(self):
+    ⚠️ The accepted cost: mainline runs its own team at the last release, not at its own HEAD, so
+    a change to hooks/ or team.yml is not exercised here until the next tag. That is the trade the
+    fleet made by locking every repo to a version; the suite and the drill repo are what catch a
+    bad change instead."""
+
+    def test_the_self_install_pins_a_release(self):
         import re
         ref = re.search(r"uses: matt-whitaker/claude-team/\.github/workflows/team\.yml@(\S+)", SELF).group(1)
-        self.assertEqual(ref, "mainline")
+        self.assertRegex(ref, r"^v\d", "the self-install pins a released tag like every consumer")
 
     def test_the_inputs_are_filled_in(self):
         self.assertNotIn("CHANGE-ME", SELF)


### PR DESCRIPTION
Every repo pins a release now, this repo's own stub included. Nothing tracks `@mainline`, so **what a repo runs is answerable from its stub alone**.

## What changed

- **`SelfInstall` inverted** — it asserted the self-stub tracked `mainline` permanently; it now asserts the stub names a `vN`, like every consumer. The stub is pinned to `@v4`.
- **CLAUDE.md's release note** — the canary paragraph is replaced by the pin-everything policy.
- **INSTALL** and **`upgrade-team`** drop the "a repo that tracks `@mainline` skips the bump" exception.
- The stub's header comment explains the new model.

## Still true

The **release commit never merges**. Its pins are `vN`; mainline's stay `mainline`, so the next release flips from a clean base. The self-stub is *not* one of those pins — it lives on mainline and bumps in an ordinary PR after a tag exists, which is why it can hold `@v4` while mainline holds `mainline`.

## ⚠️ The cost, stated

**Nothing exercises the edge any more.** A canary on `@mainline` is how the dark-dispatch race (#82) and the composite-action runtime question (#88) were caught against real work *before* any pinned consumer saw them. With every repo pinned, the suite and a drill in `claude-team-example` are the only things between a merge and a release.

**The practical consequence: drill a structural change before tagging, not after.** That's now the only place the old canary's coverage can come from.

Gate: 240 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
