### PR TITLE
Add file-a-finding, and make the driving skills reconcile cheaply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ The upgrade procedure itself is [`INSTALL.md` §0](INSTALL.md).
 
 ## Unreleased
 
-**Action required:** no — a policy change in this repo; consumers already pin.
+**Action required:** yes to adopt — re-copy `.claude/skills/`.
+
+- **A `file-a-finding` skill.** Filing a bug, a security finding, a wrong rule or an out-of-scope defect so a fixer can act without re-doing the investigation: which kind it is, which repo owns it, and what the body must carry — reproduction, measurement, the ceiling, and what could not be determined. The Architect may not rewrite a bug's body, so the report is the deliverable and a thin one is rejected rather than repaired.
+- **`take-on-story` and `diagnose-run` reconcile more cheaply (#93).** One batched query per transition, REST for issue and run status, immutable state read once, and the rate pools sampled per story. Driving three stories concurrently exhausted the GraphQL pool twice in an hour while core sat near a quarter used; the pools are independent and only the driver's polling spends them.
 
 - **Every repo pins a release; nothing tracks `@mainline`.** The canary model is retired: brewdocs.beer, claude-team-example and this repo's own stub pinned the edge so a bad change met real work before any pinned consumer saw it. All of them pin `@vN` now, and what a repo runs is answerable from its stub alone. ⚠️ The cost, accepted: nothing exercises the edge, so the suite and a drill in claude-team-example are all that stand between a merge and a release — drill a structural change **before** tagging. `SelfInstall` now asserts this repo's stub names a `vN`.
 

--- a/skills/diagnose-run/SKILL.md
+++ b/skills/diagnose-run/SKILL.md
@@ -8,6 +8,10 @@ The tracking comment looks identical in success and death, and `gh run list --li
 hands you the wrong run. Resolve the run from the task (`gh run list` matched on the task ref),
 then read **jobs → failing step → that step's log**.
 
+⚠️ **Read runs over REST**: `gh api repos/{o}/{r}/actions/runs/{id}` and `.../runs?per_page=N` bill
+the `core` pool, while `gh run view --json` bills **GraphQL** — the pool a driving session drains
+first, and the one that stops a drive when it empties (#93).
+
 ## The fingerprints
 
 Match before theorizing — each of these was measured, and each points at a different fix:

--- a/skills/file-a-finding/SKILL.md
+++ b/skills/file-a-finding/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: file-a-finding
+description: File something you found — a bug, a security finding, a wrong rule, a defect out of scope — as an issue a fixer can act on without re-doing the investigation. Use when work surfaces a problem that is not the work you were asked to do, in any repo running claude-team.
+argument-hint: [what you found]
+---
+
+A finding is filed, never swept into the current change: scope grows by surfacing follow-ups. And
+the report is the deliverable — the Architect that shapes a bug **may not rewrite its body**, so
+whatever you write is the only grounding the fixer gets. A thin report is not repaired downstream;
+it is rejected as unusable.
+
+## 1. Decide what it is
+
+| it is | when | where it goes |
+|---|---|---|
+| **bug** | something behaves wrong and you can say how | `bug` label; one branch, one PR, usually one task |
+| **security finding** | a boundary is reachable that should not be | `bug` label; the ceiling stated (see below) |
+| **spike** | you found a question, not an answer | `Spike:` title or `spike` label — no branch, ships nothing |
+| **a rule that is wrong** | the code is right and the instruction is not | the repo owning the rule, naming the rule and what it cost |
+
+⚠️ **If you cannot state a reproduction or a measurement, it is a spike, not a bug.** Filing an
+unmeasured hunch as a bug hands a fixer nothing to work from.
+
+## 2. Establish it in the repo that owns it
+
+⚠️ **The repo that owns the fix, not the one where you noticed it.** A workflow defect noticed in a
+consumer belongs to the engine; a data defect noticed by the engine belongs to the data repo.
+⚠️ `Closes owner/repo#N` does not fire across repositories — cross-repo trackers get closed by hand,
+so prefer one issue in the owning repo over a pair.
+
+## 3. Write what a fixer needs
+
+- **What is wrong**, stated so a reader can check it rather than take it on trust. Name what you
+  looked at: paths with line numbers, run ids, the command and its real output.
+- **The reproduction** — the shortest path from a clean state to the wrong behaviour.
+- **The measurement** — how often, how long, how many. "Twice in one story, both inter-wave
+  transitions" is actionable; "sometimes" is not.
+- ⚠️ **What you could NOT determine.** The section under the most pressure to skip and the most
+  valuable to keep — without it the next person re-derives the gap without knowing it was one.
+- **The ceiling**, for anything security-shaped: what it actually reaches, and what it does not.
+  A finding that overstates its blast radius gets discounted; one that understates it gets ignored.
+- **The fix you would make**, if you have one — as a proposal, marked as such. Naming the wrong fix
+  is often worth more than naming the right one.
+
+⚠️ **Evidence, not a wishlist.** A body that argues for a solution instead of describing a problem
+leaves the fixer no way to disagree with the diagnosis.
+
+## 4. Shape it for the engine, then stop
+
+- Create it **unlabelled except for the kind** (`bug` / `spike`). The front-door label is the
+  maintainer's gesture — filing is not starting.
+- **No `Branch:` or `Role:` lines.** Those are the Architect's to write; a body carrying them is a
+  task, and `team.kind()` will read it as one.
+- Prefer **one task** when it is shaped later: a bug is a fix, not a decomposition.
+- ⚠️ **Do not fix it in the current change.** Say in your report that you filed it, with the link.
+
+## Conduct
+
+- ⚠️ **Fix and report, never fix quietly** — where a repair is yours to make, the finding still gets
+  written down. Breakage that is visible is what produces the rule that prevents it.
+- **A repeat is not a re-file.** If the same finding already exists, add the new measurement to it;
+  a second issue splits the evidence.
+- **File it even when it is your own defect.** Especially then.

--- a/skills/take-on-story/SKILL.md
+++ b/skills/take-on-story/SKILL.md
@@ -22,6 +22,14 @@ consuming repo, don't assume. Post one comment on the story: driving begins, whi
 ## 2. The wave loop
 
 1. Reconcile: re-read the story and its tasks from GitHub. Never act on remembered state.
+   ⚠️ **One batched query per transition, and prefer REST.** `gh issue view` / `gh pr view` /
+   `gh run view --json` bill the **GraphQL** pool; `gh api repos/{o}/{r}/issues/{n}` and
+   `.../actions/runs/{id}` bill **core** — two independent budgets, and concurrency drains GraphQL
+   first. Driving three stories exhausted it twice in one hour while core sat near a quarter used
+   (#93). Ask for every task and story in one aliased GraphQL query rather than one call each; it
+   is also the only *consistent* read, since separate calls describe separate moments. Read
+   immutable state — titles, the task list, the `### Sequencing` section — once at drive start,
+   not every tick.
 2. Label the next wave's task with the front-door label (your `gh` is the maintainer's account —
    a human-actor event; no App required).
 3. Find the run it started (`gh run list`, newest, matched to the task) and park
@@ -48,6 +56,9 @@ silence. Post the final state on the story and hand the maintainer the PR link.
 
 - State posted at every transition, on the story issue. A fresh session must be able to resume
   from GitHub alone.
+- **Sample the pools per story**: `gh api rate_limit` costs one core call and reports `used` for
+  each. Record the delta with the wave state you already post, so a wasteful driver is a number
+  rather than a feeling — and so hitting a limit is caught before it stops a drive.
 - Labels and progress comments on this story are pre-authorized; merging, closing issues, editing
   bodies, and anything on other stories is not.
 - If the same task fails the same way twice, stop driving and report — a driver that keeps

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -686,7 +686,8 @@ class HarnessFoldedIn(unittest.TestCase):
                          "every self-reference must name claude-team now, not the retired repo")
 
     def test_the_moved_skills_point_at_the_team(self):
-        for name in ("handoff", "take-on-story", "upgrade-team", "shape-story", "diagnose-run"):
+        for name in ("handoff", "take-on-story", "upgrade-team", "shape-story", "diagnose-run",
+                     "file-a-finding"):
             self.assertTrue((ROOT / "skills" / name / "SKILL.md").exists(), name)
         self.assertNotIn("claude-harness", (ROOT / "skills/take-on-story/SKILL.md").read_text())
         self.assertNotIn("claude-harness", (ROOT / "skills/handoff/SKILL.md").read_text())


### PR DESCRIPTION
Five skills covered shaping, driving, diagnosing, handing off and upgrading — **nothing covered what to do with something you found.** The gap showed in the multi-story drill: three findings filed by hand ([#82](https://github.com/matt-whitaker/claude-team/issues/82), [fantasy-football#83](https://github.com/matt-whitaker/fantasy-football/issues/83), [#93](https://github.com/matt-whitaker/claude-team/issues/93)), each a judgement call about kind, owning repo, and what the body had to carry.

## `skills/file-a-finding`

Covers bugs, security findings, wrong rules, and out-of-scope defects:

- **Which kind** — ⚠️ no reproduction or measurement means it's a **spike**, not a bug
- **Which repo owns the fix**, not where it was noticed (and `Closes owner/repo#N` doesn't fire cross-repo)
- **What a fixer needs** — reproduction, measurement, the **ceiling** for anything security-shaped, and ⚠️ **what could not be determined**
- **Shape for the engine, then stop** — kind label only, no `Branch:`/`Role:` lines, don't fix it in the current change

It leans on the engine's own constraint: the Architect **may not rewrite a bug's body**, so the report is the deliverable and a thin one is *rejected as unusable* rather than repaired downstream.

## The #93 fix, in `take-on-story` and `diagnose-run`

`gh issue view` / `gh pr view` / `gh run view --json` bill **GraphQL**; the REST endpoints bill **core**. Driving three stories concurrently **exhausted GraphQL twice in one hour**, peaking at 5,268/5,000, while core sat near a quarter used. CI runs spend none of it — it's the driver's polling alone, and concurrency is the multiplier.

The rule now in both skills: one batched query per transition (also the only *consistent* read — separate calls describe separate moments), REST for issue and run status, immutable state read once at drive start, and the pools sampled per story so waste is a number rather than a feeling.

Gate: 240 OK. Consumers pick both up by re-copying `.claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
