### PR TITLE
Name the idle wave: an interrupted driver strands a story silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ The upgrade procedure itself is [`INSTALL.md` §0](INSTALL.md).
 
 ## Unreleased
 
-**Action required:** yes to adopt — re-copy `.claude/skills/`.
+**Action required:** yes to adopt — re-copy `.claude/rules/` and `.claude/skills/`.
+
+- **A driving session strands a wave when it is interrupted, and now says so.** The heartbeat was written for a driver that dies; its commonest catch is a driver that is merely distracted — a task closes, something pulls the session away before it labels the next wave, and nothing wakes it again because a session-driven repo has no cascade to cover for it. `take-on-story` and the session rule (revision 14) now require sweeping **every** story held before going idle and after every interruption, not only the one last touched. Measured driving five workstreams at once: a story sat finished-but-unadvanced until the maintainer noticed.
 
 - **A `file-a-finding` skill.** Filing a bug, a security finding, a wrong rule or an out-of-scope defect so a fixer can act without re-doing the investigation: which kind it is, which repo owns it, and what the body must carry — reproduction, measurement, the ceiling, and what could not be determined. The Architect may not rewrite a bug's body, so the report is the deliverable and a thin one is rejected rather than repaired.
 - **`take-on-story` and `diagnose-run` reconcile more cheaply (#93).** One batched query per transition, REST for issue and run status, immutable state read once, and the rate pools sampled per story. Driving three stories concurrently exhausted the GraphQL pool twice in an hour while core sat near a quarter used; the pools are independent and only the driver's polling spends them.

--- a/rules/claude-session.md
+++ b/rules/claude-session.md
@@ -1,6 +1,6 @@
 # claude-session
 
-**session-rule-revision: 13** · from `matt-whitaker/claude-team`
+**session-rule-revision: 14** · from `matt-whitaker/claude-team`
 
 ⚠️ **This file is entirely claude-team's — the session half.** Nothing repo-specific goes in it. To upgrade,
 **replace it** — never merge. To uninstall, delete it.
@@ -156,11 +156,16 @@ what the backlog does; this section is only how the session conducts itself whil
 - **The endgame is verified, not assumed.** After the last task closes, confirm the story's PR
   exists and says what landed; a missing PR is a diagnosis to run, never a silence to leave.
 - ⚠️ **A parked watcher is not a plan; arm a heartbeat beside it.** A watcher dies with its
-  session, and a dead driver halts a story silently. On taking a story, also arm a scheduled
+  session, and a dead driver halts a story silently — but the commoner case is a *living* driver
+  that got interrupted between a wave finishing and the next one being labelled. Both look
+  identical from outside: a story that stopped and said nothing. On taking a story, also arm a scheduled
   re-check on a long interval (the watcher is the wake path; the heartbeat is the net). Each
   heartbeat tick is the same move as any wake: reconcile the story from GitHub, advance what
   moved, re-park what died. Driving several stories is one tick sweeping all of them, not one
   heartbeat each.
+- ⚠️ **Sweep every story you hold before going idle, and after every interruption.** Not the one you
+  were last touching — all of them. A task that closed while your attention was elsewhere leaves a
+  wave nobody will label, and nothing will wake you about it.
 - **Resume is the heartbeat's move from zero.** A fresh session handed a mid-flight story reads
   the posted state and continues; nothing about the previous driver's death needs diagnosing
   first. What makes this work is the posting discipline above — protect it before optimizing

--- a/skills/take-on-story/SKILL.md
+++ b/skills/take-on-story/SKILL.md
@@ -38,6 +38,13 @@ consuming repo, don't assume. Post one comment on the story: driving begins, whi
    (20–30 min). A tick that finds everything in flight is a silent no-op; a tick that finds a
    dead watcher re-parks it; a tick after your own death is the resume. One heartbeat sweeps
    every story you are driving.
+   ⚠️ **ITS COMMONEST CATCH IS NOT A DEAD WATCHER — IT IS A WAVE THE DRIVER FORGOT TO ADVANCE.**
+   A watcher wakes you once, for one run. Anything that pulls you away between that wake and the
+   next label — a question, a second story, a diagnosis — leaves the story finished-but-unadvanced,
+   and nothing wakes you again: the repo is session-driven, so no cascade will do it for you. A
+   living driver strands a story exactly as effectively as a dead one, and it looks identical from
+   outside. Measured driving five workstreams at once: a task closed, an interrupt arrived mid-wake,
+   and the next wave was never labelled until the maintainer noticed.
 4. On wake, verify by **jobs, steps, and outcomes — never the tracking comment**:
    - Task closed, handoff posted → post progress on the story, advance to the next wave.
    - Task open with `remaining` → the author says it isn't done. Read why; re-trigger or
@@ -45,6 +52,12 @@ consuming repo, don't assume. Post one comment on the story: driving begins, whi
    - Run failed or the task closed without a handoff → diagnose from the run's steps before
      touching anything. A setup failure has no result payload; read the failing step.
 5. Repeat until the sequencing is exhausted.
+
+⚠️ **Sweep before you rest, and after every interruption.** Whenever you are about to go idle — and
+whenever anything pulls you off the loop — reconcile **every** story you hold, not just the one you
+were last touching. One batched query answers it: for each story, is there a closed task whose
+successor carries no label? That is a stranded wave, and it is the driver's to label now. Going
+idle without that sweep is how a story stops silently.
 
 ## 3. The endgame
 
@@ -61,5 +74,8 @@ silence. Post the final state on the story and hand the maintainer the PR link.
   rather than a feeling — and so hitting a limit is caught before it stops a drive.
 - Labels and progress comments on this story are pre-authorized; merging, closing issues, editing
   bodies, and anything on other stories is not.
+- ⚠️ **An interrupt does not pause the stories.** Answering a question, diagnosing another repo, or
+  taking new work does not suspend anything you are driving — runs keep finishing and waves keep
+  coming due. Sweep when you return.
 - If the same task fails the same way twice, stop driving and report — a driver that keeps
   re-triggering is suppressing the signal.


### PR DESCRIPTION
The heartbeat was written for a driver that **dies**. Its commonest catch turns out to be a driver that is merely **distracted**.

## The failure

A task closes, a watcher fires, and something pulls the session away before it labels the next wave — a question, a second story, a diagnosis. Nothing wakes it again: a session-driven repo has no cascade to cover for it. **A living driver strands a story exactly as effectively as a dead one, and from outside the two are indistinguishable.**

**Measured**, driving five workstreams in one repo: [brewdocs.beer#1349](https://github.com/matt-whitaker/brewdocs.beer/issues/1349) closed successfully, an interrupt arrived during that wake, and #1350 was never labelled. The story sat finished-but-unadvanced until the maintainer asked why it was idle.

⚠️ **No run failed and no guard could have caught it.** Every hook did its job — the gap is *between* wakes, where nothing is watching. That is why this is a driver-conduct rule and not a hook.

## The fix

**`take-on-story`** — the failure is named where the heartbeat is armed, and the remedy is concrete:

> **Sweep before you rest, and after every interruption.** Reconcile **every** story you hold, not just the one you were last touching. For each: is there a closed task whose successor carries no label? That is a stranded wave, and it is the driver's to label now.

Plus the fact the whole failure turns on, in the conduct list: **an interrupt does not pause the stories.** Runs keep finishing and waves keep coming due.

**`rules/claude-session.md`** carries the same fact — it's the file that states the heartbeat convention. Revision **13 → 14**.

Gate: 240 OK. Consumers adopt by re-copying `.claude/rules/` and `.claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
