### PR TITLE
guard-push: tokenize the way the shell does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ The upgrade procedure itself is [`INSTALL.md` §0](INSTALL.md).
 
 ## Unreleased
 
-**Action required:** yes to adopt — re-copy `.claude/rules/` and `.claude/skills/`.
+**Action required:** yes — re-copy `.claude/hooks/guard-push.py` (a security fix), `.claude/rules/` and `.claude/skills/`.
+
+- **`guard-push.py` was defeated by one ordinary quote, and is now shell-aware (brewdocs.beer-kb#50).** The guard tokenized with `str.split()`, which does not strip shell quoting the way bash does — so `git push origin "mainline"` executed identically to the bare form while the guard saw a token that was not in its set and stood down. Every one of the three protections fell to it: the push target, the `--force` flag, the `push` verb itself, and the `merge` subcommand. The same root cause ran the other way — the merge check fired on the three trigger words appearing *anywhere* in a line, so filing a report that quoted the command was blocked as if it were running it. Now `shlex.split()` per segment, the command located past prefixes and global flags (`git -C x push`, `gh -R o/r pr merge`), and the subcommand pair matched by adjacency rather than co-presence. ⚠️ **Every repo with the guard installed carries the bypassable copy until it is re-copied** — a pin bump does not reach it.
 
 - **A driving session strands a wave when it is interrupted, and now says so.** The heartbeat was written for a driver that dies; its commonest catch is a driver that is merely distracted — a task closes, something pulls the session away before it labels the next wave, and nothing wakes it again because a session-driven repo has no cascade to cover for it. `take-on-story` and the session rule (revision 14) now require sweeping **every** story held before going idle and after every interruption, not only the one last touched. Measured driving five workstreams at once: a story sat finished-but-unadvanced until the maintainer noticed.
 

--- a/templates/settings/hooks/guard-push.py
+++ b/templates/settings/hooks/guard-push.py
@@ -10,19 +10,77 @@ gets skipped.
 this package is that instructions get skipped (E17). The guard is what makes "never push the
 default branch" true of a session the way the workflow's permissions make it true of CI.
 
-⚠️ Token-match, never substring: a branch named `42-mainline-fix` must not trip the `mainline`
+⚠️ **TOKENIZE THE WAY THE SHELL DOES, OR THE GUARD MATCHES A DIFFERENT COMMAND THAN THE ONE THAT
+RUNS.** bash strips quotes before `git` ever sees an argument, so `git push origin "mainline"`
+executes identically to the bare form — but a whitespace split sees the token `"mainline"`, which
+is not the word in the set, and the guard stands down. Every protection here is defeated by one
+ordinary quote under `str.split()`. `shlex.split()` is what closes it, and both failure directions
+have the same root: without real tokenization there is no notion of an argument boundary, so a
+quoted branch name reads as a different branch and a command *described inside* an issue body
+reads as that command being run.
+
+⚠️ **Match on position, never on co-presence.** `gh pr merge` is a program and two subcommands in
+sequence; three trigger words appearing somewhere in a line is a sentence. Reading co-presence
+blocks `gh issue create --body "...gh pr merge..."` — filing a report about this guard — which is
+the false-positive mirror of the bypass and cost exactly as much.
+
+⚠️ **Token-match, never substring**: a branch named `42-mainline-fix` must not trip the `mainline`
 rule. Push targets are compared as whole refs after splitting refspecs on `:`.
+
+⚠️ **A tokenizer failure is not a licence.** An unbalanced quote makes `shlex` raise, and standing
+down there would hand back every bypass this docstring describes: a trailing `"` is the shortest
+one to type. The fallback strips quote characters and splits, which over-matches rather than
+under-matches. Only a malformed *event* fails open — that is the harness changing shape, not a
+command evading a check.
 """
+from __future__ import annotations
+
 import json
 import re
+import shlex
 import sys
 
 DEFAULT_BRANCHES = {"mainline", "main", "master"}
+# Prefixes that precede the real command without being it.
+PREFIXES = {"sudo", "command", "env", "nohup", "time", "exec", "builtin"}
+# git's own global flags that consume the following token as their value.
+GIT_VALUE_FLAGS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
 
 
 def deny(reason: str) -> None:
     print(reason, file=sys.stderr)
     sys.exit(2)
+
+
+def tokenize(segment: str) -> list[str]:
+    """Shell-accurate tokens, or an over-matching approximation when the line will not parse."""
+    try:
+        return shlex.split(segment)
+    except ValueError:
+        return segment.replace('"', " ").replace("'", " ").split()
+
+
+def command_tokens(tokens: list[str]) -> list[str]:
+    """Drop leading env assignments and prefix programs so tokens[0] is the command itself."""
+    i = 0
+    while i < len(tokens) and (ASSIGNMENT.match(tokens[i]) or tokens[i] in PREFIXES):
+        i += 1
+    return tokens[i:]
+
+
+def git_subcommand(tokens: list[str]) -> int | None:
+    """Index of git's subcommand, past its global flags. None if the line names none."""
+    i = 1
+    while i < len(tokens):
+        t = tokens[i]
+        if t in GIT_VALUE_FLAGS:
+            i += 2
+        elif t.startswith("-"):
+            i += 1
+        else:
+            return i
+    return None
 
 
 def main() -> None:
@@ -36,28 +94,34 @@ def main() -> None:
 
     # Normalise: examine each simple command in a compound line.
     for part in re.split(r"(?:&&|\|\||;|\|)", command):
-        tokens = part.strip().split()
+        tokens = command_tokens(tokenize(part))
         if not tokens:
             continue
 
-        if "git" in tokens[:2] and "push" in tokens:
-            rest = tokens[tokens.index("push") + 1:]
-            if any(t in ("--force", "-f") or t.startswith("--force-with-lease") for t in rest):
-                deny("guard-push: force-push is blocked here — reconcile by merge, or hand the "
-                     "conflict to the maintainer. (claude-team guard)")
-            for t in rest:
-                if t.startswith("-"):
-                    continue
-                # a refspec pushes to its right-hand side; a bare ref pushes to itself
-                target = t.split(":")[-1]
-                if target.removeprefix("refs/heads/") in DEFAULT_BRANCHES:
-                    deny(f"guard-push: pushing to '{target}' is blocked — the default branch "
-                         "changes by merged PR only. Push a branch and open the PR. "
-                         "(claude-team guard)")
+        if tokens[0] == "git":
+            sub = git_subcommand(tokens)
+            if sub is not None and tokens[sub] == "push":
+                rest = tokens[sub + 1:]
+                if any(t in ("--force", "-f") or t.startswith("--force-with-lease")
+                       or t.startswith("--force-if-includes") for t in rest):
+                    deny("guard-push: force-push is blocked here — reconcile by merge, or hand "
+                         "the conflict to the maintainer. (claude-team guard)")
+                for t in rest:
+                    if t.startswith("-"):
+                        continue
+                    # a refspec pushes to its right-hand side; a bare ref pushes to itself
+                    target = t.split(":")[-1]
+                    if target.removeprefix("refs/heads/") in DEFAULT_BRANCHES:
+                        deny(f"guard-push: pushing to '{target}' is blocked — the default branch "
+                             "changes by merged PR only. Push a branch and open the PR. "
+                             "(claude-team guard)")
 
-        if "gh" in tokens[:1] and "pr" in tokens and "merge" in tokens:
-            deny("guard-push: merging is the maintainer's — open or update the PR and hand over "
-                 "the link. (claude-team guard)")
+        if tokens[0] == "gh":
+            # gh's own flags may precede the subcommand pair; the pair itself is adjacent.
+            words = [t for t in tokens[1:] if not t.startswith("-")]
+            if any(a == "pr" and b == "merge" for a, b in zip(words, words[1:])):
+                deny("guard-push: merging is the maintainer's — open or update the PR and hand "
+                     "over the link. (claude-team guard)")
 
     sys.exit(0)
 

--- a/tests/test_ship.py
+++ b/tests/test_ship.py
@@ -61,6 +61,43 @@ class GuardPush(unittest.TestCase):
         self.assert_allowed("gh pr view 42")
         self.assert_allowed("ls -la")
 
+    def test_quoting_a_token_does_not_bypass_any_protection(self):
+        """bash strips quotes before git ever sees the argument, so a quoted token executes
+        identically — a tokenizer that is not shell-aware sees a different word and stands down.
+        Every protection is asserted against both quote styles, in every position it matches on."""
+        for q in ('"', "'"):
+            self.assert_blocked(f"git push origin {q}mainline{q}", "the target was merely quoted")
+            self.assert_blocked(f"git {q}push{q} origin mainline", "the verb was merely quoted")
+            self.assert_blocked(f"git push origin HEAD:{q}mainline{q}", "the refspec target")
+            self.assert_blocked(f"git push {q}--force{q} origin feature-x", "the flag")
+            self.assert_blocked(f"gh pr {q}merge{q} 42", "the subcommand")
+            self.assert_blocked(f"{q}gh{q} pr merge 42", "the program name")
+            self.assert_blocked(f"{q}git{q} push origin mainline", "the program name")
+
+    def test_the_command_is_found_past_prefixes_and_global_flags(self):
+        """`git -C x push` and `gh -R o/r pr merge` are ordinary invocations, and a check that
+        reads only the first two tokens or demands strict adjacency misses both."""
+        self.assert_blocked("git -C /some/repo push origin mainline")
+        self.assert_blocked("git -c user.name=x push --force origin feature-x")
+        self.assert_blocked("gh -R matt-whitaker/claude-team pr merge 42")
+        self.assert_blocked("env FOO=1 git push origin mainline")
+
+    def test_the_trigger_words_do_not_fire_from_inside_an_argument(self):
+        """The mirror-image failure: co-presence anywhere in the line is not an invocation. A
+        report *about* the guard must be fileable, and describing a command is not running one."""
+        self.assert_allowed(
+            'gh issue create --title "guard bug" '
+            '--body "reproduce with: gh pr merge 42, and git push origin mainline"',
+            "an issue body quoting the commands it describes is not those commands")
+        self.assert_allowed('git commit -m "explain why gh pr merge is blocked"')
+        self.assert_allowed('echo "git push origin mainline"')
+        self.assert_allowed("gh pr list --search 'merge'")
+
+    def test_unbalanced_quotes_never_relax_a_check(self):
+        """An unparseable line is not a licence. bash would reject it too, but the guard must
+        not answer a tokenizer failure by standing down."""
+        self.assert_blocked('git push origin "mainline', "an unclosed quote is not an escape")
+
     def test_compound_commands_are_examined_per_segment(self):
         self.assert_blocked("git add -A && git commit -m x && git push origin mainline")
 
@@ -86,10 +123,14 @@ class ShippedArtifacts(unittest.TestCase):
                             f"fragment references {name}, which templates/settings/hooks does "
                             "not ship — a wired-but-absent hook fails every Bash call")
 
-    def test_guard_compiles_alone(self):
-        r = subprocess.run([sys.executable, "-m", "py_compile", str(GUARD)],
+    def test_guard_runs_alone(self):
+        """Compiling is not running. `py_compile` accepts an annotation the interpreter then
+        raises on (`int | None` before 3.10), and a guard that dies on import exits non-2 —
+        which the harness reads as permission. The check has to execute it."""
+        r = subprocess.run([sys.executable, str(GUARD)], input='{"tool_input":{"command":"ls"}}',
                            capture_output=True, text=True)
         self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stderr, "", "a clean run says nothing")
 
     def test_every_skill_carries_name_and_description(self):
         self.assertTrue(SKILLS, "skills/ ships at least one skill")


### PR DESCRIPTION
Fixes the guard-push bypass reported in matt-whitaker/brewdocs.beer-kb#50. The report is accurate on every point; this is that fix, upstream in the repo that owns the file.

## What was wrong

`guard-push.py` tokenized `tool_input.command` with `str.split()`, which splits on whitespace and does not strip shell quoting. bash strips quotes before `git` ever sees an argument, so a quoted token executes identically — but the guard compared a token still carrying its quote characters against a bare word and found no match.

Reproduced against the shipped guard before the change:

| command | bash executes | old guard |
|---|---|---|
| `git push origin mainline` | push to mainline | blocked |
| `git push origin "mainline"` | push to mainline | **allowed** |
| `git "push" origin mainline` | push to mainline | **allowed** |
| `git push "--force" origin x` | force-push | **allowed** |

All three protections fall to one ordinary quote — not obfuscation, just a quoted branch name.

The same missing tokenization ran the other way. The merge check asked only whether `gh`, `pr` and `merge` each appeared *somewhere* in the line, with no notion of an argument boundary, so an issue body describing the command was blocked as if it were the command. That is how the report was found: it was unfileable in its natural phrasing, and the reporter had to substitute characters for spaces to get it past the guard.

## What changed

- **`shlex.split()` per segment**, so tokens are what bash would pass.
- **The command is located past what precedes it** — env assignments, prefix programs (`sudo`, `env`, …) and git's own global flags. `git -C /repo push origin mainline` and `gh -R o/r pr merge 42` are ordinary invocations that the old first-two-tokens check missed.
- **The subcommand pair is matched by adjacency**, not co-presence: `pr` immediately followed by `merge` among the positional words.
- **An unbalanced quote falls back to an over-matching split**, never to standing down. `shlex` raises on `git push origin "mainline`, and answering that by exiting 0 would make a trailing quote the shortest bypass of the set. Only a malformed *event* still fails open — that is the harness changing shape, not a command evading a check.

## Two things found while fixing it

**The guard raised on import and every test passed.** `int | None` in an annotation is evaluated at definition time before Python 3.10; the runtime here is 3.9.6. `test_guard_compiles_alone` used `py_compile`, which checks syntax and never executes the module, so it accepted a guard that died on every invocation. A guard that dies exits non-2 — **which the harness reads as permission**. The test now runs the guard instead of compiling it, and `from __future__ import annotations` keeps it working on whatever python3 a consumer has.

**Not determined:** `git push` with no explicit refspec, while checked out on the default branch, still passes. The command line alone does not say which branch you are on, and reading git state would give the guard a way to fail on a subprocess call. Named here rather than fixed.

## Tests

Four new cases, each proven to fail against the unfixed guard first: both quote styles in every matching position, the command found past prefixes and global flags, trigger words *not* firing from inside an argument, and an unbalanced quote not relaxing anything. Full suite 244 passing.

## ⚠️ Consumer action

**Every repo with the guard installed carries the bypassable copy** — `brewdocs.beer`, `brewdocs.beer-kb`, `claude-team-example`, `fantasy-football`, `mattwhitaker.name` and this repo all have the identical `d7cc48a2` file. A pin bump does not reach `.claude/hooks/`; it has to be re-copied. The CHANGELOG entry says so and I will open the re-copy PRs on your go.
