### PR TITLE
Upgrade this repo's own install to v4.2

### DIFF
--- a/.claude/hooks/guard-push.py
+++ b/.claude/hooks/guard-push.py
@@ -10,19 +10,77 @@ gets skipped.
 this package is that instructions get skipped (E17). The guard is what makes "never push the
 default branch" true of a session the way the workflow's permissions make it true of CI.
 
-⚠️ Token-match, never substring: a branch named `42-mainline-fix` must not trip the `mainline`
+⚠️ **TOKENIZE THE WAY THE SHELL DOES, OR THE GUARD MATCHES A DIFFERENT COMMAND THAN THE ONE THAT
+RUNS.** bash strips quotes before `git` ever sees an argument, so `git push origin "mainline"`
+executes identically to the bare form — but a whitespace split sees the token `"mainline"`, which
+is not the word in the set, and the guard stands down. Every protection here is defeated by one
+ordinary quote under `str.split()`. `shlex.split()` is what closes it, and both failure directions
+have the same root: without real tokenization there is no notion of an argument boundary, so a
+quoted branch name reads as a different branch and a command *described inside* an issue body
+reads as that command being run.
+
+⚠️ **Match on position, never on co-presence.** `gh pr merge` is a program and two subcommands in
+sequence; three trigger words appearing somewhere in a line is a sentence. Reading co-presence
+blocks `gh issue create --body "...gh pr merge..."` — filing a report about this guard — which is
+the false-positive mirror of the bypass and cost exactly as much.
+
+⚠️ **Token-match, never substring**: a branch named `42-mainline-fix` must not trip the `mainline`
 rule. Push targets are compared as whole refs after splitting refspecs on `:`.
+
+⚠️ **A tokenizer failure is not a licence.** An unbalanced quote makes `shlex` raise, and standing
+down there would hand back every bypass this docstring describes: a trailing `"` is the shortest
+one to type. The fallback strips quote characters and splits, which over-matches rather than
+under-matches. Only a malformed *event* fails open — that is the harness changing shape, not a
+command evading a check.
 """
+from __future__ import annotations
+
 import json
 import re
+import shlex
 import sys
 
 DEFAULT_BRANCHES = {"mainline", "main", "master"}
+# Prefixes that precede the real command without being it.
+PREFIXES = {"sudo", "command", "env", "nohup", "time", "exec", "builtin"}
+# git's own global flags that consume the following token as their value.
+GIT_VALUE_FLAGS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
 
 
 def deny(reason: str) -> None:
     print(reason, file=sys.stderr)
     sys.exit(2)
+
+
+def tokenize(segment: str) -> list[str]:
+    """Shell-accurate tokens, or an over-matching approximation when the line will not parse."""
+    try:
+        return shlex.split(segment)
+    except ValueError:
+        return segment.replace('"', " ").replace("'", " ").split()
+
+
+def command_tokens(tokens: list[str]) -> list[str]:
+    """Drop leading env assignments and prefix programs so tokens[0] is the command itself."""
+    i = 0
+    while i < len(tokens) and (ASSIGNMENT.match(tokens[i]) or tokens[i] in PREFIXES):
+        i += 1
+    return tokens[i:]
+
+
+def git_subcommand(tokens: list[str]) -> int | None:
+    """Index of git's subcommand, past its global flags. None if the line names none."""
+    i = 1
+    while i < len(tokens):
+        t = tokens[i]
+        if t in GIT_VALUE_FLAGS:
+            i += 2
+        elif t.startswith("-"):
+            i += 1
+        else:
+            return i
+    return None
 
 
 def main() -> None:
@@ -36,28 +94,34 @@ def main() -> None:
 
     # Normalise: examine each simple command in a compound line.
     for part in re.split(r"(?:&&|\|\||;|\|)", command):
-        tokens = part.strip().split()
+        tokens = command_tokens(tokenize(part))
         if not tokens:
             continue
 
-        if "git" in tokens[:2] and "push" in tokens:
-            rest = tokens[tokens.index("push") + 1:]
-            if any(t in ("--force", "-f") or t.startswith("--force-with-lease") for t in rest):
-                deny("guard-push: force-push is blocked here — reconcile by merge, or hand the "
-                     "conflict to the maintainer. (claude-team guard)")
-            for t in rest:
-                if t.startswith("-"):
-                    continue
-                # a refspec pushes to its right-hand side; a bare ref pushes to itself
-                target = t.split(":")[-1]
-                if target.removeprefix("refs/heads/") in DEFAULT_BRANCHES:
-                    deny(f"guard-push: pushing to '{target}' is blocked — the default branch "
-                         "changes by merged PR only. Push a branch and open the PR. "
-                         "(claude-team guard)")
+        if tokens[0] == "git":
+            sub = git_subcommand(tokens)
+            if sub is not None and tokens[sub] == "push":
+                rest = tokens[sub + 1:]
+                if any(t in ("--force", "-f") or t.startswith("--force-with-lease")
+                       or t.startswith("--force-if-includes") for t in rest):
+                    deny("guard-push: force-push is blocked here — reconcile by merge, or hand "
+                         "the conflict to the maintainer. (claude-team guard)")
+                for t in rest:
+                    if t.startswith("-"):
+                        continue
+                    # a refspec pushes to its right-hand side; a bare ref pushes to itself
+                    target = t.split(":")[-1]
+                    if target.removeprefix("refs/heads/") in DEFAULT_BRANCHES:
+                        deny(f"guard-push: pushing to '{target}' is blocked — the default branch "
+                             "changes by merged PR only. Push a branch and open the PR. "
+                             "(claude-team guard)")
 
-        if "gh" in tokens[:1] and "pr" in tokens and "merge" in tokens:
-            deny("guard-push: merging is the maintainer's — open or update the PR and hand over "
-                 "the link. (claude-team guard)")
+        if tokens[0] == "gh":
+            # gh's own flags may precede the subcommand pair; the pair itself is adjacent.
+            words = [t for t in tokens[1:] if not t.startswith("-")]
+            if any(a == "pr" and b == "merge" for a, b in zip(words, words[1:])):
+                deny("guard-push: merging is the maintainer's — open or update the PR and hand "
+                     "over the link. (claude-team guard)")
 
     sys.exit(0)
 

--- a/.claude/hooks/guard-push.py
+++ b/.claude/hooks/guard-push.py
@@ -27,6 +27,12 @@ the false-positive mirror of the bypass and cost exactly as much.
 ⚠️ **Token-match, never substring**: a branch named `42-mainline-fix` must not trip the `mainline`
 rule. Push targets are compared as whole refs after splitting refspecs on `:`.
 
+⚠️ **`shlex` LEXES; IT DOES NOT EXPAND.** `$BRANCH`, `${BRANCH}` and `$(...)` reach git as
+whatever bash resolved them to, which this guard cannot know — so a push target carrying one is
+refused rather than cleared. That is the one place it fails closed on a command it parsed
+successfully, and it is narrow on purpose: only the target of a push, where being wrong means the
+default branch.
+
 ⚠️ **A tokenizer failure is not a licence.** An unbalanced quote makes `shlex` raise, and standing
 down there would hand back every bypass this docstring describes: a trailing `"` is the shortest
 one to type. The fallback strips quote characters and splits, which over-matches rather than
@@ -41,6 +47,11 @@ import shlex
 import sys
 
 DEFAULT_BRANCHES = {"mainline", "main", "master"}
+# Flags that push refs without naming any: --all sends every local branch, the default one
+# among them; --mirror also deletes remote refs the local clone does not have.
+UNTARGETED_PUSH = ("--all", "--mirror")
+# A token the shell would expand before git sees it. shlex lexes, it does not evaluate.
+UNRESOLVED = ("$", "`")
 # Prefixes that precede the real command without being it.
 PREFIXES = {"sudo", "command", "env", "nohup", "time", "exec", "builtin"}
 # git's own global flags that consume the following token as their value.
@@ -106,11 +117,29 @@ def main() -> None:
                        or t.startswith("--force-if-includes") for t in rest):
                     deny("guard-push: force-push is blocked here — reconcile by merge, or hand "
                          "the conflict to the maintainer. (claude-team guard)")
+                if any(t in UNTARGETED_PUSH for t in rest):
+                    deny("guard-push: --all and --mirror push the default branch without naming "
+                         "it, and --mirror deletes remote refs. Push one branch by name. "
+                         "(claude-team guard)")
                 for t in rest:
                     if t.startswith("-"):
                         continue
+                    # ⚠️ `+ref` is git's OWN force shorthand: it strips the `+`, then parses the
+                    # rest as `src[:dst]`. It carries no force flag, so the check above cannot
+                    # see it, and the `+` survives into the comparison below unless stripped —
+                    # which is how one character defeated both invariants at once.
+                    if t.startswith("+"):
+                        deny("guard-push: '+' before a refspec is a force-push — reconcile by "
+                             "merge, or hand the conflict to the maintainer. (claude-team guard)")
                     # a refspec pushes to its right-hand side; a bare ref pushes to itself
                     target = t.split(":")[-1]
+                    # ⚠️ An unexpanded token is one the guard FAILED TO READ, not one it cleared.
+                    # bash resolves `$BRANCH` before git sees it; shlex does not. Refusing is the
+                    # only honest answer, and a literal ref costs the caller nothing.
+                    if any(c in target for c in UNRESOLVED):
+                        deny(f"guard-push: '{target}' expands at run time and this guard cannot "
+                             "read it, so it cannot clear it. Write the ref literally. "
+                             "(claude-team guard)")
                     if target.removeprefix("refs/heads/") in DEFAULT_BRANCHES:
                         deny(f"guard-push: pushing to '{target}' is blocked — the default branch "
                              "changes by merged PR only. Push a branch and open the PR. "

--- a/.claude/rules/claude-session.md
+++ b/.claude/rules/claude-session.md
@@ -1,8 +1,8 @@
-# claude-harness
+# claude-session
 
-**harness-rule-revision: 12** · from `matt-whitaker/claude-harness`
+**session-rule-revision: 15** · from `matt-whitaker/claude-team`
 
-⚠️ **This file is entirely claude-harness's.** Nothing repo-specific goes in it. To upgrade,
+⚠️ **This file is entirely claude-team's — the session half.** Nothing repo-specific goes in it. To upgrade,
 **replace it** — never merge. To uninstall, delete it.
 
 ⚠️ **`.claude/rules/` HOLDS INSTALLED MODULES. A REPO'S OWN INSTRUCTIONS GO IN ITS `CLAUDE.md`.**
@@ -116,20 +116,21 @@ in the commit and the PR.
 ⚠️ **A *why* that changes what you do is a fact, and stays** — a constraint, a trap, a reason the
 obvious thing is wrong. A *why* that only argues the line deserves to be there is the kind to cut.
 
-## claude-team, if this repo has it
+## Working on the team
 
-`claude-team` is the GitHub-agent orchestration, installed separately into `.claude-team/` and
-`.github/`. You will be asked to **act on** it — investigate a failed run, diagnose a workflow
-failure, repair what the custodian could not, trigger a workflow, open a PR to move a story along.
-Do that.
+The GitHub-agent orchestration ships from the same place this file does — its workflow in
+`.github/`, its overlays in `.claude-team/`, its prompts and hooks fetched at the pin. You will be
+asked to **act on** it: investigate a failed run, diagnose a workflow failure, repair what the
+custodian could not, trigger a workflow, open a PR to move a story along. Do that.
 
-⚠️ **Read how it behaves from `claude-team` itself** — its `CLAUDE.md`, `ONBOARDING.md` and its
-prompts are the source. Nothing here summarises them: a copy drifts, and the copy is what gets
-read.
+⚠️ **Read how it behaves from the team's own files** — its `CLAUDE.md`, its `INSTALL.md`, its
+prompts, and the terse `rules/claude-team.md` beside this one. Nothing here summarises them: a copy
+drifts, and the copy is what gets read.
 
 ⚠️ **The split is by whose behaviour a fact describes.** A fact about *the session* is this file's,
 even while working on the team. A fact about *the team* is the team's, even though a session is
-what reads it.
+what reads it. Two rule files, one repo: `claude-session.md` (this — how a session conducts itself)
+and `claude-team.md` (how the team's backlog works).
 
 ### Driving a story
 
@@ -154,12 +155,28 @@ what the backlog does; this section is only how the session conducts itself whil
   story and continues. If the last posted state is stale, that IS the diagnostic.
 - **The endgame is verified, not assumed.** After the last task closes, confirm the story's PR
   exists and says what landed; a missing PR is a diagnosis to run, never a silence to leave.
+- ⚠️ **A handoff is read for its CONTENTS, not for whether it exists.** Its presence tells you the
+  author finished; its four channels are the deliverable. Two of them reach an automated reader on
+  their own — `remaining` and `testingNotes` — and two reach nobody unless the driver carries them.
+  ⚠️ **A `docsCandidates` entry names a document, never an agent-instruction file** — the schema
+  refuses those, since the Writer may not write them either. Discharge them in a follow-up PR
+  **after** the story's PR lands: the last candidate arrives from the last task, when that PR is
+  already open, and a documentation fix reviewed on its own beats one appended to a diff about
+  something else. `supersedes` is reported, never applied by hand —
+  it names an issue's criteria or a spec that now reads the old way, and editing those is the
+  maintainer's. ⚠️ **Where a finding pokes at the scope of the subject matter, ask rather than
+  act**: the licence is to discharge what the authors decided, not to widen the story.
 - ⚠️ **A parked watcher is not a plan; arm a heartbeat beside it.** A watcher dies with its
-  session, and a dead driver halts a story silently. On taking a story, also arm a scheduled
+  session, and a dead driver halts a story silently — but the commoner case is a *living* driver
+  that got interrupted between a wave finishing and the next one being labelled. Both look
+  identical from outside: a story that stopped and said nothing. On taking a story, also arm a scheduled
   re-check on a long interval (the watcher is the wake path; the heartbeat is the net). Each
   heartbeat tick is the same move as any wake: reconcile the story from GitHub, advance what
   moved, re-park what died. Driving several stories is one tick sweeping all of them, not one
   heartbeat each.
+- ⚠️ **Sweep every story you hold before going idle, and after every interruption.** Not the one you
+  were last touching — all of them. A task that closed while your attention was elsewhere leaves a
+  wave nobody will label, and nothing will wake you about it.
 - **Resume is the heartbeat's move from zero.** A fresh session handed a mid-flight story reads
   the posted state and continues; nothing about the previous driver's death needs diagnosing
   first. What makes this work is the posting discipline above — protect it before optimizing
@@ -183,7 +200,7 @@ An `InstructionsLoaded` hook logs every instruction file and why it loaded. ⚠�
 `~/.claude/settings.json`.** A hook in a project's `.claude/settings.json` does **not** run in a
 folder whose workspace-trust dialog has not been accepted, and a `-p` session never counts as
 accepting it — so a project-scoped hook that silently never fires reads exactly like a rule that
-never loaded. Setup is in `claude-harness`'s `SETUP.md`.
+never loaded. Setup is in the team's `INSTALL.md`.
 
 ⚠️ **Compaction is not the explanation.** These files reload after a `/compact` — `compact` is one
 of the hook's own `load_reason` values.
@@ -192,5 +209,5 @@ of the hook's own `load_reason` values.
 
 A local session writes it to memory. A cloud session **commits it to this repo's `CLAUDE.md`** —
 not to a rule, which is for what was installed. ⚠️ **If the lesson would be true in any repo it
-belongs upstream in `claude-harness`, not here.** Keeping one local makes it invisible to every
+belongs upstream in `claude-team`, not here.** Keeping one local makes it invisible to every
 other repo that would hit the same trap.

--- a/.claude/skills/diagnose-run/SKILL.md
+++ b/.claude/skills/diagnose-run/SKILL.md
@@ -8,6 +8,10 @@ The tracking comment looks identical in success and death, and `gh run list --li
 hands you the wrong run. Resolve the run from the task (`gh run list` matched on the task ref),
 then read **jobs → failing step → that step's log**.
 
+⚠️ **Read runs over REST**: `gh api repos/{o}/{r}/actions/runs/{id}` and `.../runs?per_page=N` bill
+the `core` pool, while `gh run view --json` bills **GraphQL** — the pool a driving session drains
+first, and the one that stops a drive when it empties (#93).
+
 ## The fingerprints
 
 Match before theorizing — each of these was measured, and each points at a different fix:

--- a/.claude/skills/file-a-finding/SKILL.md
+++ b/.claude/skills/file-a-finding/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: file-a-finding
+description: File something you found — a bug, a security finding, a wrong rule, a defect out of scope — as an issue a fixer can act on without re-doing the investigation. Use when work surfaces a problem that is not the work you were asked to do, in any repo running claude-team.
+argument-hint: [what you found]
+---
+
+A finding is filed, never swept into the current change: scope grows by surfacing follow-ups. And
+the report is the deliverable — the Architect that shapes a bug **may not rewrite its body**, so
+whatever you write is the only grounding the fixer gets. A thin report is not repaired downstream;
+it is rejected as unusable.
+
+## 1. Decide what it is
+
+| it is | when | where it goes |
+|---|---|---|
+| **bug** | something behaves wrong and you can say how | `bug` label; one branch, one PR, usually one task |
+| **security finding** | a boundary is reachable that should not be | `bug` label; the ceiling stated (see below) |
+| **spike** | you found a question, not an answer | `Spike:` title or `spike` label — no branch, ships nothing |
+| **a rule that is wrong** | the code is right and the instruction is not | the repo owning the rule, naming the rule and what it cost |
+
+⚠️ **If you cannot state a reproduction or a measurement, it is a spike, not a bug.** Filing an
+unmeasured hunch as a bug hands a fixer nothing to work from.
+
+## 2. Establish it in the repo that owns it
+
+⚠️ **The repo that owns the fix, not the one where you noticed it.** A workflow defect noticed in a
+consumer belongs to the engine; a data defect noticed by the engine belongs to the data repo.
+⚠️ `Closes owner/repo#N` does not fire across repositories — cross-repo trackers get closed by hand,
+so prefer one issue in the owning repo over a pair.
+
+## 3. Write what a fixer needs
+
+- **What is wrong**, stated so a reader can check it rather than take it on trust. Name what you
+  looked at: paths with line numbers, run ids, the command and its real output.
+- **The reproduction** — the shortest path from a clean state to the wrong behaviour.
+- **The measurement** — how often, how long, how many. "Twice in one story, both inter-wave
+  transitions" is actionable; "sometimes" is not.
+- ⚠️ **What you could NOT determine.** The section under the most pressure to skip and the most
+  valuable to keep — without it the next person re-derives the gap without knowing it was one.
+- **The ceiling**, for anything security-shaped: what it actually reaches, and what it does not.
+  A finding that overstates its blast radius gets discounted; one that understates it gets ignored.
+- **The fix you would make**, if you have one — as a proposal, marked as such. Naming the wrong fix
+  is often worth more than naming the right one.
+
+⚠️ **Evidence, not a wishlist.** A body that argues for a solution instead of describing a problem
+leaves the fixer no way to disagree with the diagnosis.
+
+## 4. Shape it for the engine, then stop
+
+- Create it **unlabelled except for the kind** (`bug` / `spike`). The front-door label is the
+  maintainer's gesture — filing is not starting.
+- **No `Branch:` or `Role:` lines.** Those are the Architect's to write; a body carrying them is a
+  task, and `team.kind()` will read it as one.
+- Prefer **one task** when it is shaped later: a bug is a fix, not a decomposition.
+- ⚠️ **Do not fix it in the current change.** Say in your report that you filed it, with the link.
+
+## Conduct
+
+- ⚠️ **Fix and report, never fix quietly** — where a repair is yours to make, the finding still gets
+  written down. Breakage that is visible is what produces the rule that prevents it.
+- **A repeat is not a re-file.** If the same finding already exists, add the new measurement to it;
+  a second issue splits the evidence.
+- **File it even when it is your own defect.** Especially then.

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: handoff
+description: Write a handoff brief for another Claude session — when work crosses into a different repo, or a finding belongs to a codebase this session is not set up for. Produces raw markdown the maintainer carries over, built so the receiving session can falsify the premise before acting on it.
+argument-hint: [target repo or task]
+---
+
+A session cannot talk to another session. The maintainer carries the brief, so it has to stand
+on its own.
+
+## Before writing
+
+Establish what the receiving session must check first, and what evidence you actually hold —
+paths with line numbers, commands and their real output, run ids, measurements. Anything you
+assert without evidence, mark as unverified rather than dropping it.
+
+## Structure
+
+1. **Header** — from, to, scope, and the single file or area in play. State up front if no
+   change is wanted in the sending repo.
+2. **Verify the premise** — the file, command or state the receiving session checks *before*
+   acting, and what to do if it turns out to be wrong. Say "declare this void and report back"
+   explicitly. ⚠️ A handoff that cannot be falsified by its reader is just an instruction to
+   comply.
+3. **The finding, with evidence** — the conclusion *and* what grounds it, so the reader can
+   catch an error rather than inherit it, and never re-derives what you already paid for.
+4. **The change to make** — bounded. Name what belongs to a different repo or a different
+   decision.
+5. **What NOT to do** — including known-and-accepted gaps it will notice and should not re-file
+   as discoveries.
+6. **Ship discipline for the target repo** — issue, branch, gate, PR body, board.
+7. **What could not be determined** — and why. Never drop this section.
+
+## Hazards
+
+⚠️ Where the target repo runs an agent workflow, a literal front-door handle in an issue or PR
+comment starts a real run, and backticks do not protect it. Write around it, and say why, so
+the receiving session inherits the discipline.
+
+⚠️ Do not send a summary. Send what the session needs to act and to disagree.
+
+## Deliver
+
+Write it to a markdown file and hand over the path. Offer to publish it as an artifact with a
+copy button when the maintainer will move it by hand — raw markdown, never rendered, because
+rendered output is not what a session reads.
+
+<!-- skill-revision: 3 — from matt-whitaker/claude-team/skills/handoff.
+     Bumps only when THIS skill changes, never because SETUP.md did.
+     Reinstall per SETUP.md §Skills: copy into the consuming repo's .claude/skills/. -->

--- a/.claude/skills/take-on-story/SKILL.md
+++ b/.claude/skills/take-on-story/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: take-on-story
+description: Drive a claude-team story end to end as the session-side driver — sequence its tasks, watch the runs, land the story PR. Use when the maintainer hands over a whole story ("take on this story", "drive #N"), on a repo whose cascade is dark.
+argument-hint: [story issue ref]
+---
+
+You are replacing the cascade, not the roles. Every task still runs in CI; you decide *when*,
+watch *whether it worked*, and keep the story's state legible. The conduct rules are in
+`rules/claude-session.md` §Driving a story — this skill is the procedure.
+
+## 0. Refuse the wrong repo
+
+Read the stub (`.github/workflows/claude.yml`): a bot named in `allowed_bots` means a live
+cascade, and two drivers race for the same labels. Say so and stop. Drive dark repos only.
+
+## 1. Orient
+
+Fetch. Read the story issue fresh: its branch line, its sequencing section, its open tasks, any
+handoff comments already posted. The team's own files define what these mean — read them from the
+consuming repo, don't assume. Post one comment on the story: driving begins, which wave is next.
+
+## 2. The wave loop
+
+1. Reconcile: re-read the story and its tasks from GitHub. Never act on remembered state.
+   ⚠️ **One batched query per transition, and prefer REST.** `gh issue view` / `gh pr view` /
+   `gh run view --json` bill the **GraphQL** pool; `gh api repos/{o}/{r}/issues/{n}` and
+   `.../actions/runs/{id}` bill **core** — two independent budgets, and concurrency drains GraphQL
+   first. Driving three stories exhausted it twice in one hour while core sat near a quarter used
+   (#93). Ask for every task and story in one aliased GraphQL query rather than one call each; it
+   is also the only *consistent* read, since separate calls describe separate moments. Read
+   immutable state — titles, the task list, the `### Sequencing` section — once at drive start,
+   not every tick.
+2. Label the next wave's task with the front-door label (your `gh` is the maintainer's account —
+   a human-actor event; no App required).
+3. Find the run it started (`gh run list`, newest, matched to the task) and park
+   `gh run watch <id>` as a background task. Do other work or wait; the exit wakes you.
+   ⚠️ On taking the story, also arm a **heartbeat** — a scheduled re-check on a long interval
+   (20–30 min). A tick that finds everything in flight is a silent no-op; a tick that finds a
+   dead watcher re-parks it; a tick after your own death is the resume. One heartbeat sweeps
+   every story you are driving.
+   ⚠️ **ITS COMMONEST CATCH IS NOT A DEAD WATCHER — IT IS A WAVE THE DRIVER FORGOT TO ADVANCE.**
+   A watcher wakes you once, for one run. Anything that pulls you away between that wake and the
+   next label — a question, a second story, a diagnosis — leaves the story finished-but-unadvanced,
+   and nothing wakes you again: the repo is session-driven, so no cascade will do it for you. A
+   living driver strands a story exactly as effectively as a dead one, and it looks identical from
+   outside. Measured driving five workstreams at once: a task closed, an interrupt arrived mid-wake,
+   and the next wave was never labelled until the maintainer noticed.
+4. On wake, verify by **jobs, steps, and outcomes — never the tracking comment**:
+   - Task closed, handoff posted → **harvest it** (below), post progress, advance to the next wave.
+   - Task open with `remaining` → the author says it isn't done. Read why; re-trigger or
+     surface to the maintainer. Do not close it yourself.
+   - Run failed or the task closed without a handoff → diagnose from the run's steps before
+     touching anything. A setup failure has no result payload; read the failing step.
+5. Repeat until the sequencing is exhausted.
+
+### Harvesting a handoff
+
+⚠️ **READ THE HANDOFF'S CONTENTS, NOT ITS PRESENCE.** Four channels are forced out of every author;
+two reach an automated reader on their own and two reach nobody unless you carry them. A story can
+run green to completion with both accumulating on its issue and nothing consuming either. Measured
+across twelve closed stories: seventeen `docsCandidates` and fourteen `supersedes`, none actioned.
+
+Parse the JSON block in each handoff comment and carry it to the endgame:
+
+| channel | what you do with it |
+|---|---|
+| `remaining` | already handled in step 4 — the task is not finished |
+| `testingNotes` | nothing; the Tester reads it on its own trigger |
+| `docsCandidates` | accumulate, and discharge at the endgame |
+| `decisions` | a hook appends them to a running log on the story, so the record keeps itself. Its `supersedes` field does not: carry each one to the endgame and report what now reads the old way |
+
+⚠️ **A candidate names a document, never an agent-instruction file** — the schema refuses those,
+because the Writer is barred from them exactly as the authors are. What reaches you is a
+specification or a reference that a late discovery left saying the wrong thing: small, concrete,
+and worth applying. A fact belonging in agent instructions arrives under 🔔 Maintainer instead,
+and that is the maintainer's to act on.
+
+⚠️ **An empty array is an answer and needs nothing.** The author considered it and found nothing;
+that is not a gap to chase.
+
+⚠️ **Sweep before you rest, and after every interruption.** Whenever you are about to go idle — and
+whenever anything pulls you off the loop — reconcile **every** story you hold, not just the one you
+were last touching. One batched query answers it: for each story, is there a closed task whose
+successor carries no label? That is a stranded wave, and it is the driver's to label now. Going
+idle without that sweep is how a story stops silently.
+
+## 3. The endgame
+
+After the last task closes, confirm the story's PR exists, targets the right branch, and its body
+reflects what landed. A missing PR is a diagnosis (the team documents the usual causes), never a
+silence. Post the final state on the story and hand the maintainer the PR link.
+
+Then discharge what you harvested:
+
+- **`docsCandidates` → a follow-up PR, after the story's PR has landed.** One PR per story,
+  applying the notes you accept to the files they name. ⚠️ **Never onto the story's own branch**:
+  the last candidate arrives from the last task, by which point that PR is open or merged, and a
+  documentation fix reviewed on its own is worth more than one appended to a diff about something
+  else. ⚠️ **A candidate is a proposal.** Weigh each, apply what earns its place, and say which you
+  dropped and why — rejecting all of them is a correct outcome.
+- **`supersedes` → report, do not edit.** Each one names something that now reads the old way — an
+  issue's acceptance criteria, a spec id, a sibling task. Editing an issue body is not pre-authorized;
+  list them on the story with what each points at and let the maintainer act.
+- **🔔 Maintainer and ❓Blocked sections → surface them.** A question whose only reader was the
+  run's own transcript has no reader at all.
+
+⚠️ **Where a finding pokes at the scope of the subject matter, ask rather than act.** The licence
+here is to discharge what the authors already decided, not to widen the story.
+
+## Throughout
+
+- State posted at every transition, on the story issue. A fresh session must be able to resume
+  from GitHub alone.
+- **Sample the pools per story**: `gh api rate_limit` costs one core call and reports `used` for
+  each. Record the delta with the wave state you already post, so a wasteful driver is a number
+  rather than a feeling — and so hitting a limit is caught before it stops a drive.
+- Labels and progress comments on this story are pre-authorized; merging, closing issues, editing
+  bodies, and anything on other stories is not.
+- ⚠️ **An interrupt does not pause the stories.** Answering a question, diagnosing another repo, or
+  taking new work does not suspend anything you are driving — runs keep finishing and waves keep
+  coming due. Sweep when you return.
+- If the same task fails the same way twice, stop driving and report — a driver that keeps
+  re-triggering is suppressing the signal.

--- a/.claude/skills/upgrade-team/SKILL.md
+++ b/.claude/skills/upgrade-team/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: upgrade-team
+description: Bring an already-installed claude-team consumer up to the current version — bump the pin, reconcile the stub, and re-copy the half a pin cannot carry (rules, skills, labels, settings). Use when a repo running claude-team needs updating, or a session is unsure whether an install is current.
+argument-hint: [target repo]
+---
+
+An installed repo drifts because the install runs once and the upgrade never does. This is the
+upgrade, and `INSTALL.md` §0 is its authority — read it there; this skill is the order to work in
+and the conduct around it, not a second copy of the logic.
+
+## Detect where the target is
+
+The pin *is* the version. There is no second number to invent.
+
+```bash
+grep -o 'team\.yml@[^ ]*' <target>/.github/workflows/claude.yml   # installed
+git ls-remote --tags https://github.com/matt-whitaker/claude-team  # available
+```
+
+
+## The order (INSTALL.md §0 is the detail)
+
+1. **Read `CHANGELOG.md` from the installed ref to the current tag.** Every version heading has an
+   `**Action required:**` line. All `no` → only the bump and the re-copy remain.
+2. **Bump the `uses:` ref, and re-fetch `rules/claude-team.md` so its `team-ref` matches it.** They
+   are one fact in two places; a mismatch is the half-done upgrade nothing else can see.
+3. **Reconcile the stub — never recreate it.** Diff against `templates/consumer-stub.yml`. A new
+   input shows up here and nowhere else, because a consumer's stub is frozen.
+4. **Leave overlays alone unless the CHANGELOG says otherwise** — except the one trap it names: an
+   overlay composes after the base and wins, so a base rule that tightened a role's scope reaches
+   nothing if the overlay still grants it. Grep the overlays for the old grant.
+5. **Re-copy the half a pin cannot carry — every time, unconditionally.** These are committed files
+   and GitHub state, so no ref bump ever touches them:
+   - `.claude/rules/claude-team.md` and `.claude/rules/claude-session.md`
+   - `.claude/skills/*`, `.claude/settings.json`, `.claude/hooks/guard-push.py`
+   - the label loop (§4) — labels live in GitHub, not the clone
+   - the board, and any secret or setting a CHANGELOG entry newly requires
+6. **Drill again (in the drill repo) only if something structural moved** — a new input, a routing
+   change, a changed role set. A prose release does not earn a run.
+
+## Conduct
+
+- **Ship it as install ships: branch → PR → merge.** Never push the target's default branch, and
+  nothing takes effect until merge — `issues` events run the workflow from the default branch, so a
+  workflow fix does not reach an in-flight story until the default branch carries it.
+- **Report which happened**: installed, upgraded from ref N with what the CHANGELOG said to do, or
+  already current. "Bumped and hoped" is the failure this skill exists to end.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,7 +64,7 @@ jobs:
       pull-requests: write
       actions: read
       id-token: write
-    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v4.1
+    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v4.2
     with:
       project_owner: matt-whitaker
       project_number: "9"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,7 +64,7 @@ jobs:
       pull-requests: write
       actions: read
       id-token: write
-    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v4
+    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v4.1
     with:
       project_owner: matt-whitaker
       project_number: "9"

--- a/tests/test_harness_boundary.py
+++ b/tests/test_harness_boundary.py
@@ -1,6 +1,7 @@
 """⚠️ THE LAYER SPLIT IS ONLY REAL IF SOMETHING CHECKS IT.
 
-How a *session* works is `claude-harness`, installed here as `.claude/rules/claude-harness.md`.
+How a *session* works is `rules/claude-session.md`, installed here as
+`.claude/rules/claude-session.md` like any other consumer.
 How the *GitHub agents* work is this repo. One question sorts them — who invoked it — and the
 whole point of separating them is that "does this serve a purpose?" becomes answerable, because a
 file can no longer be serving the other layer.
@@ -15,20 +16,20 @@ import pathlib
 import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
-RULE = ROOT / ".claude/rules/claude-harness.md"
+RULE = ROOT / ".claude/rules/claude-session.md"
 
 
-class TheHarnessRuleIsInstalled(unittest.TestCase):
+class TheSessionRuleIsInstalled(unittest.TestCase):
     def test_the_rule_is_present(self):
-        self.assertTrue(RULE.exists(), f"{RULE} is missing — the harness is not installed here")
+        self.assertTrue(RULE.exists(), f"{RULE} is missing — the session rule is not installed here")
 
     def test_it_records_where_it_came_from_and_at_what_revision(self):
         """⚠️ Without the marker, "is this stale?" costs a full re-read of the file every time —
         the exact cost the install exists to remove. It is also what makes the upgrade a replace
         rather than a comparison."""
         text = RULE.read_text(encoding="utf-8")
-        self.assertRegex(text, r"harness-rule-revision: \d+")
-        self.assertIn("claude-harness", text)
+        self.assertRegex(text, r"session-rule-revision: \d+")
+        self.assertIn("claude-session", text)
 
     def test_it_is_replaced_not_merged(self):
         """⚠️ Nothing of this repo's may be written into it, or an upgrade clobbers repo content
@@ -63,7 +64,7 @@ class RulesHoldInstalledModulesOnly(unittest.TestCase):
 
     def test_the_manifest_is_the_modules_and_nothing_else(self):
         found = sorted(p.name for p in self.RULES.glob("*.md"))
-        self.assertEqual(found, ["claude-harness.md"])
+        self.assertEqual(found, ["claude-session.md"])
 
     def test_this_repos_own_facts_live_in_claude_md(self):
         """The content that used to sit beside the module. It has one home, and a session reading


### PR DESCRIPTION
Upgrade this repo's own install to v4.1 — the same bump every consumer makes, plus the parts the harness merge left half-done here.

## The security half

**`guard-push.py` was defeated by one ordinary quote.** `str.split()` does not strip shell quoting, so `git push origin "mainline"` executed identically to the bare form while the guard compared against a token carrying literal quote characters and stood down. Every protection fell to it. The whole fleet carried the byte-identical file (`d7cc48a2`); this brings `ef198056`.

## What the merge left behind here

- **`.claude/rules/claude-harness.md` was still installed, at revision 12** — a file whose repo was folded into this one. Replaced by `claude-session.md` at revision 15.
- **`.claude/skills/` carried two of the six skills this repo ships.** Now all six, including `file-a-finding` and `take-on-story`.
- **`tests/test_harness_boundary.py` asserted the retired filename**, and asserted it was the *only* rule installed — so the check meant to catch a half-done rename was itself pinning the arrangement the rename replaced. Retargeted; it checks the same property against `claude-session.md`.

## What is not here, deliberately

**`rules/claude-team.md` is not installed into `.claude/rules/`.** It exists for a session in a *consumer* clone, which has no copy of this repo's `CLAUDE.md`. Here that file is present and is the specification. `CLAUDE.md` already warns that its hierarchy table is asserted equal to the rule's "because a third statement of the same facts is a third thing that drifts" — installing it here would make a fourth. Say if you want it anyway and I will add it.

## Files

Pin `@v4` → `@v4.1`, `.claude/rules/`, `.claude/skills/`, `.claude/settings.json`, `.claude/hooks/guard-push.py`.

Suite: 246 passing.
