### PR TITLE
guard-push: treat + as force, and refuse what it cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ The upgrade procedure itself is [`INSTALL.md` §0](INSTALL.md).
 
 ## Unreleased
 
-**Action required:** n/a — nothing has landed since `v4.1`.
+**Action required:** yes to adopt — re-copy `.claude/hooks/guard-push.py` (a security fix).
+
+- **`git push origin +mainline` defeated both of guard-push's push invariants at once (#98).** `+ref` is git's own force shorthand: it strips the `+`, then parses `src[:dst]`. It carries none of the force flags, so the force check missed it, and the `+` survived into the target comparison, so `+mainline` never matched `mainline`. Shorter to type than the quoting bypass v4.1 closed, and it force-pushed the default branch. Filed by the Security role on the post-merge run of the change that introduced it. Also closed alongside it: `--all` and `--mirror`, which push the default branch without naming it and which no positional check could see, and a push target carrying `$`, `${…}` or `` ` `` — `shlex` lexes but does not expand, so such a target is now **refused rather than cleared**. That is the one place the guard fails closed on a command it parsed, scoped to the target of a push.
+- **Security files every issue with `--label bug`.** Its prompt named no label at all, and it holds `gh issue create` but not `gh issue edit`, so a label omitted at creation could never be added. `team.kind()` derives `story` from the absence of a marker, so an unlabelled security report reads as a story and gets shaped into tasks instead of fixed — and is missing from every board filter meanwhile. A test pins the flag against the allowlist that has to permit it.
 
 ## v4.1
 

--- a/prompts/security.md
+++ b/prompts/security.md
@@ -20,6 +20,18 @@ Start with the diff, then read the files it touches. Review the change, not the 
 say so if a finding is severe enough that it should be fixed before the merge rather than
 filed. That call is the maintainer's; yours is to make it clearly.
 
+⚠️ **EVERY ISSUE YOU FILE CARRIES `--label bug`.** Pass it on `gh issue create`; you hold no
+`gh issue edit`, so a label you leave off cannot be added later by you or by any hook. An
+unlabelled issue is not merely untidy: the kind is derived from the labels, and an issue with
+none reads as a **story**, so a security report gets shaped into tasks by the Architect instead
+of fixed. It is also invisible to every board filter, which is where the maintainer looks.
+
+⚠️ **Never the front-door label.** `bug` says what the issue *is*; starting work on it is the
+maintainer's gesture, and a role does not chain another role.
+
+⚠️ **A question rather than a finding is `--label spike`** — no reproduction, no measurement,
+nothing an owner could act on yet. Say which it is; do not file a hunch as a bug.
+
 ## Working inside a narrow allowlist
 
 Your shell allowlist is deliberately small — this job runs with repository credentials in

--- a/templates/settings/hooks/guard-push.py
+++ b/templates/settings/hooks/guard-push.py
@@ -27,6 +27,12 @@ the false-positive mirror of the bypass and cost exactly as much.
 ⚠️ **Token-match, never substring**: a branch named `42-mainline-fix` must not trip the `mainline`
 rule. Push targets are compared as whole refs after splitting refspecs on `:`.
 
+⚠️ **`shlex` LEXES; IT DOES NOT EXPAND.** `$BRANCH`, `${BRANCH}` and `$(...)` reach git as
+whatever bash resolved them to, which this guard cannot know — so a push target carrying one is
+refused rather than cleared. That is the one place it fails closed on a command it parsed
+successfully, and it is narrow on purpose: only the target of a push, where being wrong means the
+default branch.
+
 ⚠️ **A tokenizer failure is not a licence.** An unbalanced quote makes `shlex` raise, and standing
 down there would hand back every bypass this docstring describes: a trailing `"` is the shortest
 one to type. The fallback strips quote characters and splits, which over-matches rather than
@@ -41,6 +47,11 @@ import shlex
 import sys
 
 DEFAULT_BRANCHES = {"mainline", "main", "master"}
+# Flags that push refs without naming any: --all sends every local branch, the default one
+# among them; --mirror also deletes remote refs the local clone does not have.
+UNTARGETED_PUSH = ("--all", "--mirror")
+# A token the shell would expand before git sees it. shlex lexes, it does not evaluate.
+UNRESOLVED = ("$", "`")
 # Prefixes that precede the real command without being it.
 PREFIXES = {"sudo", "command", "env", "nohup", "time", "exec", "builtin"}
 # git's own global flags that consume the following token as their value.
@@ -106,11 +117,29 @@ def main() -> None:
                        or t.startswith("--force-if-includes") for t in rest):
                     deny("guard-push: force-push is blocked here — reconcile by merge, or hand "
                          "the conflict to the maintainer. (claude-team guard)")
+                if any(t in UNTARGETED_PUSH for t in rest):
+                    deny("guard-push: --all and --mirror push the default branch without naming "
+                         "it, and --mirror deletes remote refs. Push one branch by name. "
+                         "(claude-team guard)")
                 for t in rest:
                     if t.startswith("-"):
                         continue
+                    # ⚠️ `+ref` is git's OWN force shorthand: it strips the `+`, then parses the
+                    # rest as `src[:dst]`. It carries no force flag, so the check above cannot
+                    # see it, and the `+` survives into the comparison below unless stripped —
+                    # which is how one character defeated both invariants at once.
+                    if t.startswith("+"):
+                        deny("guard-push: '+' before a refspec is a force-push — reconcile by "
+                             "merge, or hand the conflict to the maintainer. (claude-team guard)")
                     # a refspec pushes to its right-hand side; a bare ref pushes to itself
                     target = t.split(":")[-1]
+                    # ⚠️ An unexpanded token is one the guard FAILED TO READ, not one it cleared.
+                    # bash resolves `$BRANCH` before git sees it; shlex does not. Refusing is the
+                    # only honest answer, and a literal ref costs the caller nothing.
+                    if any(c in target for c in UNRESOLVED):
+                        deny(f"guard-push: '{target}' expands at run time and this guard cannot "
+                             "read it, so it cannot clear it. Write the ref literally. "
+                             "(claude-team guard)")
                     if target.removeprefix("refs/heads/") in DEFAULT_BRANCHES:
                         deny(f"guard-push: pushing to '{target}' is blocked — the default branch "
                              "changes by merged PR only. Push a branch and open the PR. "

--- a/tests/test_ship.py
+++ b/tests/test_ship.py
@@ -98,6 +98,32 @@ class GuardPush(unittest.TestCase):
         not answer a tokenizer failure by standing down."""
         self.assert_blocked('git push origin "mainline', "an unclosed quote is not an escape")
 
+    def test_a_leading_plus_is_a_force_marker(self):
+        """`+ref` is git's own force shorthand — it strips the `+`, then parses `src[:dst]` with
+        an implicit dst. It carries none of the force FLAGS, and the `+` survives into the target
+        comparison, so both checks miss it at once. Shorter to type than the quoting bypass."""
+        self.assert_blocked("git push origin +mainline", "git's force shorthand")
+        self.assert_blocked("git push origin +refs/heads/main")
+        self.assert_blocked("git push origin +HEAD:mainline")
+        self.assert_blocked("git push origin +feature-x",
+                            "forcing a feature branch is still a force-push")
+
+    def test_pushes_that_name_no_branch_still_reach_the_default_one(self):
+        """`--all` pushes every local branch, the default one among them; `--mirror` also deletes
+        remote refs the local clone lacks. Neither names a branch, so a check that only inspects
+        positional tokens sees nothing to object to."""
+        self.assert_blocked("git push --all origin")
+        self.assert_blocked("git push --mirror origin")
+
+    def test_an_unresolvable_target_is_refused_rather_than_assumed_safe(self):
+        """shlex lexes; it does not expand. `$BRANCH` reaches git as whatever bash resolved it
+        to, which the guard cannot know — so it cannot be cleared, and a guard on the default
+        branch does not wave through what it failed to read."""
+        self.assert_blocked("BRANCH=mainline; git push origin $BRANCH")
+        self.assert_blocked("git push origin ${BRANCH}")
+        self.assert_blocked("git push origin $(cat /tmp/b)")
+        self.assert_allowed("git push origin feature-x", "a literal ref is readable and fine")
+
     def test_compound_commands_are_examined_per_segment(self):
         self.assert_blocked("git add -A && git commit -m x && git push origin mainline")
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -635,6 +635,27 @@ class ReleasePins(unittest.TestCase):
                          "rules/claude-team.md's team-ref must flip with every other pin")
 
 
+class SecurityFilesLabelled(unittest.TestCase):
+    """⚠️ The Security role holds `gh issue create` and NOT `gh issue edit`, so a label it omits
+    at creation cannot be added afterwards by it or by any hook. `team.kind()` derives `story`
+    from the absence of a marker, so an unlabelled security report is read as a story and shaped
+    into tasks rather than fixed — and it is missing from every board filter meanwhile. Measured:
+    claude-team#98, a real guard bypass, filed with no labels at all."""
+
+    def test_the_prompt_requires_the_kind_label_on_every_issue(self):
+        text = (ROOT / "prompts/security.md").read_text(encoding="utf-8")
+        self.assertIn("--label bug", text,
+                      "the Security prompt must name the flag, not merely the intent — it is the "
+                      "only moment the label can be applied")
+
+    def test_the_allowlist_can_actually_pass_it(self):
+        """A prompt telling a role to do what its allowlist forbids is the failure this pairs
+        against: `gh issue create` must be granted, and the role must not be told to reach for
+        an edit it does not hold."""
+        self.assertIn("Bash(gh issue create:*)", TEAM)
+        self.assertNotIn("Bash(gh issue edit:*)", TEAM)
+
+
 class SelfInstall(unittest.TestCase):
     """This repo consumes itself, and its stub pins a release like every other consumer.
 


### PR DESCRIPTION
Closes #98 — filed by the **Security** role on the post-merge run of #97, the change that introduced the code it found the hole in. The finding is correct.

## The bypass

`+ref` is git's own force shorthand: git strips the leading `+`, then parses the rest as `src[:dst]`. It defeats **both** push invariants at once:

- The force check looks for `-f` / `--force` / `--force-with-lease*` / `--force-if-includes*`. A `+`-prefixed ref carries none of them.
- The target check treats `+mainline` as an ordinary positional — it does not start with `-`, so it is not skipped — and compares the literal `"+mainline"` against `{"mainline","main","master"}`. The `+` is never stripped.

```
git push origin +mainline
```

No quoting, no prefixes, no global flags. Shorter than the bypass #97 closed, and it force-pushes the default branch from the ordinary idle state.

## Two more, which the report did not name

Probing around it found these, verified the same way:

| command | old | new |
|---|---|---|
| `git push --all origin` | **allowed** | blocked |
| `git push --mirror origin` | **allowed** | blocked |

`--all` pushes every local branch, the default one among them; `--mirror` also **deletes** remote refs the local clone does not have. Neither names a branch, so a check that only inspects positional tokens has nothing to object to.

## The `$VAR` gap, and why this one fails closed

The report is right that `tokenize()`'s "shell-accurate" claim overreached — `shlex` lexes, it does not evaluate. `git push origin $BRANCH` reaches git as whatever bash resolved, which the guard cannot know.

There is no fix that reads it, so a push target containing `$`, `${…}` or a backtick is now **refused rather than cleared**. An unexpanded token is one the guard *failed to read*, not one it approved, and waving it through is the only outcome that is definitely wrong.

⚠️ **This is the one place the guard fails closed on a command it parsed successfully**, and it is deliberately narrow — only the target of a push, where being wrong means the default branch. `git commit -m "costs $5"` and `echo $HOME && git push origin feature-x` both still pass. The docstring's claim is corrected to say what `shlex` actually does.

## The labelling half

**#98 was filed with no labels at all**, and `prompts/security.md` contains no mention of labels — the role was never told to apply one.

That is worse than untidy. Security holds `Bash(gh issue create:*)` and **not** `gh issue edit`, so a label omitted at creation cannot be added afterwards by the role or by any hook. And `team.kind()` derives `story` from the absence of a marker — so an unlabelled security report reads as a **story** and gets shaped into tasks by the Architect rather than fixed, while being invisible to every board filter.

The prompt now requires `--label bug` on every issue, names `spike` for a question rather than a finding, and forbids the front-door label (starting work stays the maintainer's gesture). A test pins the flag against the allowlist that has to permit it.

## Tests

Three new cases, each proven to fail against the unfixed guard first — the `+` marker in four forms, the untargeted pushes, and the unresolvable target — plus the two Security-labelling assertions. Suite: **251 passing**.

## ⚠️ Consumer action

Re-copy `.claude/hooks/guard-push.py`. The six v4.1 upgrade PRs currently open carry the **previous** guard, which has this bypass — they still close the quoting hole and are worth merging, but a follow-up re-copy is needed after this lands, or I can update those branches in place. Say which you prefer.
