### PR TITLE
A driving session adopts the issues its roles file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ The upgrade procedure itself is [`INSTALL.md` §0](INSTALL.md).
 
 ## Unreleased
 
-**Action required:** n/a — nothing has landed since `v4.2`.
+**Action required:** yes to adopt — re-copy `.claude/rules/` and `.claude/skills/`.
+
+- **A driving session adopts the issues its roles file.** A role files a finding rather than sweeping it into the change, and the Security role files on every merge — but each arrives authored by the App, the same author for every role, so **the issue says nothing about who wrote it or what it came out of** and nothing downstream claims it. The driver now adopts each one at the wake that closes the task: it separates findings from its Architect's tasks by sub-issue membership, labels the kind, and comments the attribution — role, task, story, run. ⚠️ The kind label is load-bearing: `team.kind()` reads an unlabelled issue as a **story**, so a bug with no label is decomposed into tasks instead of fixed. Measured on the two known cases: **both arrived with no kind label** — brewdocs.beer#1373 sat 23 hours before the maintainer labelled it by hand, and claude-team#98, a critical guard bypass, was filed unlabelled by the Security role. ⚠️ Attribution is bounded by what timing can show — one live role run identifies the filer, several do not, and the driver names candidates rather than guessing. Session rule revision 16.
 
 ## v4.2
 

--- a/rules/claude-session.md
+++ b/rules/claude-session.md
@@ -1,6 +1,6 @@
 # claude-session
 
-**session-rule-revision: 15** · from `matt-whitaker/claude-team`
+**session-rule-revision: 16** · from `matt-whitaker/claude-team`
 
 ⚠️ **This file is entirely claude-team's — the session half.** Nothing repo-specific goes in it. To upgrade,
 **replace it** — never merge. To uninstall, delete it.
@@ -155,6 +155,17 @@ what the backlog does; this section is only how the session conducts itself whil
   story and continues. If the last posted state is stale, that IS the diagnostic.
 - **The endgame is verified, not assumed.** After the last task closes, confirm the story's PR
   exists and says what landed; a missing PR is a diagnosis to run, never a silence to leave.
+- ⚠️ **AN ISSUE A ROLE FILED IS THE DRIVER'S TO PLACE.** Roles file findings as they work — a
+  defect out of scope, a security review on merge — and every one arrives authored by the App, so
+  the issue carries no trace of which role wrote it or what it came out of. Nothing downstream
+  claims it. While driving, adopt each one at the wake that closes the task: label its kind
+  (`bug`, or `spike` for a question), and comment the attribution — the role, the task and story,
+  the run. ⚠️ **The kind label is not optional and not cosmetic**: an issue with no kind reads as
+  a story, so an unlabelled bug is decomposed into tasks instead of being fixed. ⚠️ **Never the
+  front-door label** — placing an issue is not starting it. ⚠️ **Attribute only as far as the
+  evidence goes.** Timing identifies the filing run when one role run was live; with several in
+  flight it does not, and saying which anyway is a guess wearing a fact's clothes. Name the
+  candidates and mark the inference.
 - ⚠️ **A handoff is read for its CONTENTS, not for whether it exists.** Its presence tells you the
   author finished; its four channels are the deliverable. Two of them reach an automated reader on
   their own — `remaining` and `testingNotes` — and two reach nobody unless the driver carries them.

--- a/skills/take-on-story/SKILL.md
+++ b/skills/take-on-story/SKILL.md
@@ -53,6 +53,50 @@ consuming repo, don't assume. Post one comment on the story: driving begins, whi
      touching anything. A setup failure has no result payload; read the failing step.
 5. Repeat until the sequencing is exhausted.
 
+### Adopting what a role filed
+
+⚠️ **A ROLE FILES ISSUES WHILE IT WORKS, AND NOTHING DOWNSTREAM CLAIMS THEM.** A finding out of
+scope is filed rather than swept into the change — so an authoring run can leave a bug behind, and
+the Security role files on every merge. They arrive authored by the App, which is the same author
+for every role, so **the issue itself says nothing about who wrote it or what it came out of**.
+Left alone it is an issue nobody can place, in a backlog where placement is how work is found.
+
+Do this at the wake that closes each task, not at the endgame — an unplaced issue is at its most
+traceable in the minutes after it appears.
+
+**1. Find them.** Bot-authored issues created since the drive began:
+
+```bash
+gh api "repos/{o}/{r}/issues?state=all&since=<drive-start>&per_page=50" \
+  -q '.[] | select(.user.type=="Bot") | select(.pull_request==null) | .number'
+```
+
+⚠️ **The tasks your Architect created are in that list too**, and they are not findings. The
+discriminator is **sub-issue membership**: a task is a child of its story, a filed finding is a
+child of nothing. You already hold the task list, so this costs no call.
+
+**2. Attribute it, and only as far as the evidence goes.** An issue's creation time falls inside
+the window of the run that filed it (`created_at`..`updated_at` on the run, from the runs you
+parked).
+
+- **Exactly one role run live in that window** → that run's role filed it. Say so plainly.
+- ⚠️ **More than one** → you cannot tell from timing, and driving several stories at once makes
+  this the ordinary case, not the edge. Name the candidates, say which the content points to, and
+  **mark that half as inferred**. Do not present a guess as a fact.
+
+**3. Label the kind immediately** — `bug`, or `spike` for a question with no reproduction. ⚠️
+**Never the front-door label**: placing an issue is not starting it, and starting it is the
+maintainer's gesture. ⚠️ An issue carrying no kind reads as a **story**, so an unlabelled bug gets
+decomposed into tasks rather than fixed.
+
+**4. Write the attribution onto the issue**, as a comment — the body is the filing role's and is
+not yours to rewrite. Name the role, the task and story it came out of, the run, and whether the
+attribution is certain or inferred. ⚠️ **This is the whole point of the step**: the label makes it
+findable, the comment makes it explicable.
+
+**5. Report every one at the endgame**, with the story. A finding adopted and never mentioned is
+one the maintainer learns about from a board.
+
 ### Harvesting a handoff
 
 ⚠️ **READ THE HANDOFF'S CONTENTS, NOT ITS PRESENCE.** Four channels are forced out of every author;
@@ -103,6 +147,8 @@ Then discharge what you harvested:
   list them on the story with what each points at and let the maintainer act.
 - **🔔 Maintainer and ❓Blocked sections → surface them.** A question whose only reader was the
   run's own transcript has no reader at all.
+- **Issues the roles filed → list them**, each with its kind, what filed it, and one line on what
+  it is. They are the part of a story's output that leaves no trace in its PR.
 
 ⚠️ **Where a finding pokes at the scope of the subject matter, ask rather than act.** The licence
 here is to discharge what the authors already decided, not to widen the story.


### PR DESCRIPTION
The session runner now identifies, labels and attributes the issues its roles file.

## The gap

A role files a finding rather than sweeping it into the change, and Security files on every merge. Every one of them arrives authored by the App — **the same author for every role** — so the issue carries no trace of which role wrote it or what work it came out of. Nothing downstream claims it: no hook, no later role, no cascade.

Measured on the two known cases, and **both arrived with no kind label at all**:

| issue | filed | labelled | gap |
|---|---|---|---|
| brewdocs.beer#1373 | `2026-08-26T21:49:31Z` | by the maintainer, by hand | **23 hours** |
| claude-team#98 (a critical guard bypass) | `2026-08-26T21:48:37Z` | by hand, during triage | — |

⚠️ That is not cosmetic. `team.kind()` derives `story` from the absence of a marker, so an unlabelled bug is read as a **story** — meaning the Architect decomposes it into tasks instead of anyone fixing it.

## Why the session and not the workflow

A hook could label on creation, but it cannot say *which role* filed the issue: by the time the issue exists, the run that filed it is one of several that may be in flight, and the App authored all of them. The driver is the only actor that knows which task it labelled, which run it parked, and when — so attribution is knowable there and nowhere else.

## The procedure

Added to `take-on-story` §2, run at the wake that closes each task:

1. **Find them** — bot-authored issues created since the drive began, PRs excluded.
2. **Separate findings from tasks** — the Architect's tasks are in that same list. The discriminator is **sub-issue membership**: a task is a child of its story, a filed finding is a child of nothing. Costs no call; the driver already holds the task list.
3. **Attribute, bounded by the evidence.** The issue's creation time falls inside the filing run's window.
4. **Label the kind immediately** — `bug`, or `spike` for a question with no reproduction. ⚠️ Never the front-door label: placing an issue is not starting it.
5. **Comment the attribution** — role, task, story, run, and whether it is certain or inferred. The body stays the filing role's; the comment is the driver's.
6. **Report every one at the endgame.**

## ⚠️ The limit, stated rather than hidden

**Timing does not always identify the filer, and concurrent driving makes that the ordinary case.** #1373 was created at `21:49:31Z` with *two* role runs live — `33016750615` (#1370) and `33016450894` (#1364, a different story). One live run means certain attribution; several means candidates. The skill requires naming the candidates and marking the inference rather than presenting the likely one as fact.

For #1373 the content settles it — the finding is entirely in `batch-shopping/`, which is #1370's subject — but that is a reading of the body, not evidence from the run, and the comment says so.

## Applied to the real cases

Both existing findings now carry attribution comments: [brewdocs.beer#1373](https://github.com/matt-whitaker/brewdocs.beer/issues/1373#issuecomment-5445061817) (inferred, with the ambiguity shown) and [claude-team#98](https://github.com/matt-whitaker/claude-team/issues/98#issuecomment-5445062040) (certain — one role job ran, and it was Security).

## Tests

**None added, and that is a real gap in this PR.** The change is procedural prose in a skill and a rule, with no artifact to bind an assertion against — unlike #100, where the routing table could be pinned to the handoff schema. A grep for a heading would pass without the procedure being correct, which is the kind of test that gave the guard false confidence earlier today. Suite unchanged at **251 passing**.

`rules/claude-session.md` revision **15 → 16**.

## ⚠️ Consumer action

Re-copy `.claude/rules/` and `.claude/skills/`. No pin change; this is prose the session reads, not workflow behaviour.
