### PR TITLE
Upgrade to claude-team v4.3 — restores authoring runs

### DIFF
--- a/.claude/rules/claude-session.md
+++ b/.claude/rules/claude-session.md
@@ -1,6 +1,6 @@
 # claude-session
 
-**session-rule-revision: 15** · from `matt-whitaker/claude-team`
+**session-rule-revision: 17** · from `matt-whitaker/claude-team`
 
 ⚠️ **This file is entirely claude-team's — the session half.** Nothing repo-specific goes in it. To upgrade,
 **replace it** — never merge. To uninstall, delete it.
@@ -67,6 +67,46 @@ confirmation rather than the trigger.
 - **Destructive and outward-facing work waits for an explicit instruction** — merging,
   force-pushing, deleting, anything beyond opening a PR. Approval in one context does not extend
   to the next.
+- ⚠️ **EVERY TURN ENDS WITH A HANDOVER BLOCK, AND IT SAYS WHOSE MOVE IT IS.** The maintainer
+  cannot see your branches, your watchers or your intentions; they see a wall of text that stops.
+  A push described in prose reads exactly like delivered work, and work you believe is running
+  reads exactly like work that is. ⚠️ **The block is unconditional** — its *absence* must never be
+  the signal, because a turn where you simply omitted it would then be indistinguishable from one
+  where nothing is needed. It opens with a horizontal rule so it is findable by shape, not by
+  reading.
+
+  Exactly one verdict, first line, always one of these three:
+
+  | verdict | means |
+  |---|---|
+  | **⏳ Your move** | something is blocked on the maintainer. List each item, what it is, and what it unblocks. |
+  | **🔄 In flight** | work is genuinely running and will wake you. Name it — run id, watcher, PR — so waiting is known to be productive. |
+  | **✅ Idle** | nothing is running and nothing is needed. Say what you would do next. |
+
+  ⚠️ **An item is not *Your move* until it is actually actionable.** A pushed branch with no open
+  PR is not a maintainer action; it is undelivered work, and listing it as theirs hides that.
+  ⚠️ **Reconcile *In flight* before claiming it** — from GitHub and from your own task list, not
+  from memory. A watcher that died and a run that finished both look like progress from the
+  inside, and a turn that ends "in flight" while nothing runs is the failure this block exists to
+  remove.
+
+  ⚠️ **Both can be true, and the verdict is still one.** Runs in flight *and* something blocked
+  on the maintainer is **⏳ Your move**, with the in-flight work listed beneath it — their time is
+  what the verdict is about.
+
+  ```
+  ---
+
+  **⏳ Your move**
+
+  | what | where | unblocks |
+  |---|---|---|
+  | Merge | [claude-team#108](https://github.com/matt-whitaker/claude-team/pull/108) | cutting v4.3 |
+  | Approve the workflow run | [brewdocs.beer#1376](https://github.com/matt-whitaker/brewdocs.beer/pull/1376) | its CI has never run |
+
+  **In flight:** none.
+  ```
+
 - **Report what actually happened.** Failed tests get quoted. A skipped step gets said. Finished
   and verified gets stated plainly without hedging. ⚠️ **What could not be determined is the part
   that matters most** — say it before it becomes a surprise. A message telling someone not to look
@@ -155,6 +195,17 @@ what the backlog does; this section is only how the session conducts itself whil
   story and continues. If the last posted state is stale, that IS the diagnostic.
 - **The endgame is verified, not assumed.** After the last task closes, confirm the story's PR
   exists and says what landed; a missing PR is a diagnosis to run, never a silence to leave.
+- ⚠️ **AN ISSUE A ROLE FILED IS THE DRIVER'S TO PLACE.** Roles file findings as they work — a
+  defect out of scope, a security review on merge — and every one arrives authored by the App, so
+  the issue carries no trace of which role wrote it or what it came out of. Nothing downstream
+  claims it. While driving, adopt each one at the wake that closes the task: label its kind
+  (`bug`, or `spike` for a question), and comment the attribution — the role, the task and story,
+  the run. ⚠️ **The kind label is not optional and not cosmetic**: an issue with no kind reads as
+  a story, so an unlabelled bug is decomposed into tasks instead of being fixed. ⚠️ **Never the
+  front-door label** — placing an issue is not starting it. ⚠️ **Attribute only as far as the
+  evidence goes.** Timing identifies the filing run when one role run was live; with several in
+  flight it does not, and saying which anyway is a guess wearing a fact's clothes. Name the
+  candidates and mark the inference.
 - ⚠️ **A handoff is read for its CONTENTS, not for whether it exists.** Its presence tells you the
   author finished; its four channels are the deliverable. Two of them reach an automated reader on
   their own — `remaining` and `testingNotes` — and two reach nobody unless the driver carries them.

--- a/.claude/skills/take-on-story/SKILL.md
+++ b/.claude/skills/take-on-story/SKILL.md
@@ -53,6 +53,50 @@ consuming repo, don't assume. Post one comment on the story: driving begins, whi
      touching anything. A setup failure has no result payload; read the failing step.
 5. Repeat until the sequencing is exhausted.
 
+### Adopting what a role filed
+
+⚠️ **A ROLE FILES ISSUES WHILE IT WORKS, AND THE ISSUE CANNOT SAY WHO FILED IT.** A finding out of
+scope is filed rather than swept into the change, and Security files on every merge. All of them
+are authored by the same App account, so nothing on the issue names the role or the work it came
+out of, and nothing downstream claims it.
+
+**The run says so itself.** Every role reports `filed` — the issue numbers it created — through
+its forced schema, and a hook comments the attribution onto each one. So the ordinary path is to
+*read* the attribution, not to deduce it.
+
+Do this at the wake that closes each task; an unplaced issue is at its most traceable in the
+minutes after it appears.
+
+1. **Read `filed` from the handoff.** Those numbers are the run's own account of what it brought
+   into existence — first-party and certain. `[]` is the common answer and a real one.
+2. **Check each one is placed.** The hook writes the attribution; you supply the **kind label** —
+   `bug`, or `spike` for a question with no reproduction. ⚠️ **Never the front-door label**:
+   placing an issue is not starting it, and starting it is the maintainer's gesture. ⚠️ An issue
+   carrying no kind reads as a **story**, so an unlabelled bug is decomposed into tasks instead of
+   being fixed.
+3. **Report every one at the endgame**, with the story.
+
+#### The backstop, for what `filed` missed
+
+⚠️ **Do not make this the primary path.** It is here because a run can die before its hook runs,
+and because a role can under-report. Sweep for bot-authored issues created since the drive began
+that no handoff claimed:
+
+```bash
+gh api "repos/{o}/{r}/issues?state=all&since=<drive-start>&per_page=50" \
+  -q '.[] | select(.user.type=="Bot") | select(.pull_request==null) | .number'
+```
+
+⚠️ **Your Architect's tasks are in that list and are not findings.** The discriminator is
+**sub-issue membership**: a task is a child of its story, a filed finding is a child of nothing.
+You already hold the task list, so this costs no call.
+
+⚠️ **Attribute only as far as the evidence goes.** An unclaimed issue can be bracketed against the
+run windows you parked, and that is weaker than a declaration: **one** live role run identifies the
+filer, **several** do not — and driving concurrent stories makes several the ordinary case, not the
+edge. Name the candidates, say which the content points to, and mark that half as inferred. A guess
+presented as a fact is worse than an open question.
+
 ### Harvesting a handoff
 
 ⚠️ **READ THE HANDOFF'S CONTENTS, NOT ITS PRESENCE.** Four channels are forced out of every author;
@@ -67,6 +111,7 @@ Parse the JSON block in each handoff comment and carry it to the endgame:
 | `remaining` | already handled in step 4 — the task is not finished |
 | `testingNotes` | nothing; the Tester reads it on its own trigger |
 | `docsCandidates` | accumulate, and discharge at the endgame |
+| `filed` | the issues this run created — adopt each one (above): label its kind, check the hook's attribution landed, report it at the endgame |
 | `decisions` | a hook appends them to a running log on the story, so the record keeps itself. Its `supersedes` field does not: carry each one to the endgame and report what now reads the old way |
 
 ⚠️ **A candidate names a document, never an agent-instruction file** — the schema refuses those,
@@ -103,6 +148,8 @@ Then discharge what you harvested:
   list them on the story with what each points at and let the maintainer act.
 - **🔔 Maintainer and ❓Blocked sections → surface them.** A question whose only reader was the
   run's own transcript has no reader at all.
+- **Issues the roles filed → list them**, each with its kind, what filed it, and one line on what
+  it is. They are the part of a story's output that leaves no trace in its PR.
 
 ⚠️ **Where a finding pokes at the scope of the subject matter, ask rather than act.** The licence
 here is to discharge what the authors already decided, not to widen the story.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,7 +64,7 @@ jobs:
       pull-requests: write
       actions: read
       id-token: write
-    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v4.2
+    uses: matt-whitaker/claude-team/.github/workflows/team.yml@v4.3
     with:
       project_owner: matt-whitaker
       project_number: "9"


### PR DESCRIPTION
⚠️ **This repo's authoring runs are currently broken.** Merging this fixes them.

## What is wrong right now

`v4.2` ships a `schemas/handoff.json` containing an apostrophe. Every schema is inlined into `claude_args` inside single quotes, and the workflow deliberately fails rather than emit a value that would mangle every flag after it:

```
*"'"*) echo "::error::handoff.json contains a single quote"; exit 1 ;;
```

So the **authors job dies at `Load the handoff schema`, before the model is called**. Any task routed to an Implementor, Designer, Tester or Writer fails there.

Observed in production: [brewdocs.beer run 33115798722](https://github.com/matt-whitaker/brewdocs.beer/actions/runs/33115798722) failed at `team / authors` → step `Load the handoff schema`, on a real story.

`v4` was clean. `v4.1` and `v4.2` both carry it. **`v4.3` fixes it**, and a test now compacts every schema and asserts it is one quote-free line — plus one asserting the workflow guards every schema it inlines.

## What else v4.3 brings

- **A role names the issues it filed, and a hook attributes them.** An issue cannot say which role created it — every role writes through the same App account. The handoff schema gains a required `filed` channel, Security gains a forced schema of its own, and `stamp-filed.py` comments role, task, story and run onto each issue named.
- **A driving session ends every turn saying whose move it is** — blocked on the maintainer, genuinely in flight, or idle. Session rule **15 → 17**.
- **A driving session adopts the issues its roles file**, labelling the kind so an unlabelled bug is not read as a story and decomposed into tasks.

## Files

Pin `@v4.2` → `@v4.3`, plus the half a pin cannot carry: `.claude/rules/`, `.claude/skills/`, `.claude/settings.json`, `.claude/hooks/guard-push.py`. Overlays untouched — v4.3 narrows no role's scope.
